### PR TITLE
Fix perl 5.10 issue with `//=` syntax

### DIFF
--- a/lib/Net/SAML2/Protocol/AuthnRequest.pm
+++ b/lib/Net/SAML2/Protocol/AuthnRequest.pm
@@ -100,7 +100,9 @@ around BUILDARGS => sub {
 
     my %params = @_;
     if ($params{nameid_format}) {
-        $params{nameidpolicy_format} //= $params{nameid_format};
+        unless (defined $params{nameidpolicy_format}) {
+            $params{nameidpolicy_format} = $params{nameid_format};
+        }
     }
 
     return $self->$orig(%params);


### PR DESCRIPTION
Signed-off-by: Wesley Schwengle <wesley@opndev.io>