### PR TITLE
Remove dependencies from dist.ini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Change where needed when you want to re-use this on your production
 # server
 
-FROM perl:slim-stretch
+FROM perl:latest
 
 WORKDIR /tmp/build
 
@@ -15,12 +15,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     gcc \
-# libssl1.0-dev is required, because Crypt::OpenSSL::{X509,RSA,VerifyX509} do not
-# support libssl1.1 yet.
-# It can be removed once
-# https://github.com/dsully/perl-crypt-openssl-x509/issues/53 and related bugs
-# for the other projects are fixed.
-    libssl1.0-dev \
+    libssl-dev \
     libxml2-dev \
     xmlsec1 \
     openssl \
@@ -30,17 +25,10 @@ COPY dev-bin/cpanm .
 RUN ./cpanm Moose
 
 COPY cpanfile .
-
 RUN ./cpanm --installdeps .
-
-# A newer version of Crypt::OpenSSL::RSA has been released on may 31st
-# 2018. This breaks Net::SAML2. Force it at 0.28 for the time being
-#RUN ./cpanm "Crypt::OpenSSL::RSA@0.28"
 
 COPY . .
 
 RUN prove -lv
-
 RUN ./cpanm --test-only .
-
 RUN perl Makefile.PL && make && make test

--- a/dist.ini
+++ b/dist.ini
@@ -51,49 +51,16 @@ copy = cpanfile, Makefile.PL, README
 skip = Saml2Test
 
 [Prereqs / RuntimeRequires]
-Crypt::OpenSSL::Bignum = 0
-Crypt::OpenSSL::Random = 0
-Crypt::OpenSSL::RSA = 0
-Crypt::OpenSSL::Verify = 0
-Crypt::OpenSSL::X509 = 0
-DateTime = 0
-DateTime::Format::XSD = 0
-DateTime::HiRes = 0
-Exporter = 0
-File::Slurper = 0
-HTTP::Request::Common = 0
-IO::Compress::RawDeflate = 0
-IO::Uncompress::RawInflate = 0
-List::Util = 0
-LWP::Protocol::https = 0
-LWP::UserAgent = 0
-MIME::Base64 = 0
-Moose = 0
-Moose::Role = 0
-MooseX::Types::Common::String = 0
-MooseX::Types::DateTime = 0
-MooseX::Types::URI = 0
-namespace::autoclean = 0
-URI = 0
-URI::Encode = 0
-URI::QueryParam = 0
 XML::Enc = 0.05
-XML::Generator = 0
-XML::LibXML = 0
-XML::LibXML::XPathContext = 0
 XML::Sig = 0.52
 XML::Writer = 0.625
+; Here because otherwise only on test you get to pull in this dependency
+; which might only be an issue with cpm or if you run --no-test with cpanm
+XML::LibXML::XPathContext = 0
+; Here because it isn't provided by Crypt::OpenSSL::RSA
+Crypt::OpenSSL::Bignum = 0
 
 [Prereqs / TestRequires]
-Import::Into = 0
-Path::Tiny = 0
-URI::URL = 0
-Test::Deep = 0
-Test::Exception = 0
-Test::Fatal = 0
-Test::Lib = 0
-Test::More = 0
-Test::NoTabs = 0
 Test::Pod = 1.14
 Test::Pod::Coverage = 1.04
 


### PR DESCRIPTION
The dist.ini has AutoPreqs enabled, so most of them, if not all should be found
automaticly. Only those who require special treatement, eg, need to have a
minimum version must stay.

Signed-off-by: Wesley Schwengle <wesley@opndev.io>