### PR TITLE
Make some URI's optional in the constructor

### DIFF
--- a/lib/Net/SAML2/SP.pm
+++ b/lib/Net/SAML2/SP.pm
@@ -104,9 +104,9 @@ has 'key'    => (isa => 'Str', is => 'ro', required => 1);
 has 'cacert' => (isa => 'Maybe[Str]', is => 'ro', required => 1);
 
 has 'error_url'        => (isa => 'Str', is => 'ro', required => 1);
-has 'slo_url_soap'     => (isa => 'Str', is => 'ro', required => 1);
+has 'slo_url_soap'     => (isa => 'Str', is => 'ro', required => 0, predicate => 'has_slo_url_soap');
+has 'slo_url_post'     => (isa => 'Str', is => 'ro', required => 0, predicate => 'has_slo_url_post');
 has 'slo_url_redirect' => (isa => 'Str', is => 'ro', required => 1);
-has 'slo_url_post'     => (isa => 'Str', is => 'ro', required => 1);
 has 'acs_url_post'     => (isa => 'Str', is => 'ro', required => 1);
 has 'acs_url_artifact' => (isa => 'Str', is => 'ro', required => 1);
 
@@ -359,21 +359,29 @@ sub generate_metadata {
 
                 )
             ),
-            $x->SingleLogoutService(
-                $md,
-                { Binding => 'urn:oasis:names:tc:SAML:2.0:bindings:SOAP',
-                  Location  => $self->url . $self->slo_url_soap },
-            ),
+            $self->has_slo_url_soap ?
+                $x->SingleLogoutService(
+                    $md,
+                    { Binding => 'urn:oasis:names:tc:SAML:2.0:bindings:SOAP',
+                      Location  => $self->url . $self->slo_url_soap },
+                ) : (),
+
             $x->SingleLogoutService(
                 $md,
                 { Binding => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
                   Location  => $self->url . $self->slo_url_redirect },
             ),
-            $x->SingleLogoutService(
-                $md,
-                { Binding => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-                  Location  => $self->url . $self->slo_url_post },
-            ),
+
+            $self->has_slo_url_post ?
+                $x->SingleLogoutService(
+                    $md,
+                    {
+                        Binding =>
+                            'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+                        Location => $self->url . $self->slo_url_post
+                    },
+                ) : (),
+
             $x->AssertionConsumerService(
                 $md,
                 { Binding => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',

--- a/t/02-create-sp.t
+++ b/t/02-create-sp.t
@@ -36,6 +36,27 @@ if (is(@ssos, 2, "Got two assertionConsumerService(s)")) {
     );
 }
 
+{
+    my $node = get_single_node_ok($xpath,
+        '//md:SingleLogoutService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"]'
+    );
+    is(
+        $node->getAttribute('Location'),
+        'http://localhost:3000/slo-soap',
+        ".. with the correct location"
+    );
+
+    $node = get_single_node_ok($xpath,
+        '//md:SingleLogoutService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"]'
+    );
+    is(
+        $node->getAttribute('Location'),
+        'http://localhost:3000/sls-post-response',
+        ".. with the correct location"
+    );
+}
+
+
 get_single_node_ok($xpath, '//ds:Signature');
 
 {
@@ -64,9 +85,7 @@ get_single_node_ok($xpath, '//ds:Signature');
         org_contact      => 'test@example.com',
 
         org_url          => 'http://www.example.com',
-        slo_url_soap     => '/slo-soap',
         slo_url_redirect => '/sls-redirect-response',
-        slo_url_post     => '/sls-post-response',
         acs_url_post     => '/consumer-post',
         acs_url_artifact => '/consumer-artifact',
         error_url        => '/error',
@@ -154,11 +173,17 @@ get_single_node_ok($xpath, '//ds:Signature');
         ok($keyname->textContent, "... and we have a key name");
     }
 
-}
+    # These nodes are missing
+    ok(!$xpath->findnodes('//md:SingleLogoutService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"]'),
+        "No node found for slo_url_soap");
+    ok(!$xpath->findnodes('//md:SingleLogoutService[@Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"]'),
+        "No node found for slo_url_post");
 
-{
-    # Test Signature
-    my $node = get_single_node_ok($xpath, '/node()/ds:Signature');
+    {
+        # Test Signature
+        my $node = get_single_node_ok($xpath, '/node()/ds:Signature');
+
+    }
 
 }
 


### PR DESCRIPTION
Not all URI's are mandatory for metadata creation

* slo_url_post
* slo_url_soap

These can now be omitted in the constructor and we are able to build the
correct metadata.

Signed-off-by: Wesley Schwengle <wesley@opndev.io>