### PR TITLE
Only use defaults/required attrs in net_saml2_sp() test method

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,7 @@ name: linux
 
 on:
   - push
+  - pull_request
 
 jobs:
   perl:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
           echo '35c896266e4257793387ba22d5d76078  pari-2.3.4.tar.gz' | md5sum -c - ;
           tar zxf pari-2.3.4.tar.gz;
           cd - ;
-          cpanm Math::Pari;
+          cpanm Math::Pari Moose;
           cpanm --installdeps . ;
       - name: Build Module
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,15 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install Net::SAML2 Depends
         run: |
-          apt-get install libxml2 make gcc;
+          apt-get install libxml2 make gcc wget;
+          mkdir -p $HOME/.cpanm ;
+          cd $HOME/.cpanm;
+          wget https://src.fedoraproject.org/repo/pkgs/perl-Math-Pari/pari-2.3.4.tar.gz/35c896266e4257793387ba22d5d76078/pari-2.3.4.tar.gz \
+            -O pari-2.3.4.tar.gz ;
+          echo '35c896266e4257793387ba22d5d76078  pari-2.3.4.tar.gz' | md5sum -c - ;
+          tar zxf pari-2.3.4.tar.gz;
+          cd - ;
+          cpanm Math::Pari;
           cpanm --installdeps . ;
       - name: Build Module
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Net::SAML2 Depends
         run: |
           apt-get install libxml2 make gcc;
-          curl -sL https://cpanmin.us/ | perl - -nq --installdeps . ;
+          cpanm --installdeps . ;
       - name: Build Module
         run: |
           perl Makefile.PL;

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,18 +9,20 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          - '5.10'
-          - '5.12'
-          - '5.14'
-          - '5.16'
-          - '5.18'
-          - '5.20'
-          - '5.22'
-          - '5.24'
+          - '5.10-buster'
+          - '5.12-buster'
+          - '5.14-buster'
+          - '5.16-buster'
+          - '5.18-buster'
+          - '5.20-buster'
+          - '5.22-buster'
+          - '5.24-buster'
           - '5.26'
           - '5.28'
           - '5.30'
           - '5.32'
+          - '5.34'
+          - '5.36'
     container:
       image: perl:${{ matrix.perl-version }}
     steps:

--- a/t/lib/Test/Net/SAML2/Util.pm
+++ b/t/lib/Test/Net/SAML2/Util.pm
@@ -34,26 +34,24 @@ use URI::URL;
 
 sub net_saml2_sp {
     return Net::SAML2::SP->new(
-        id               => 'http://localhost:3000',
-        url              => 'http://localhost:3000',
-        cert             => 't/sign-nopw-cert.pem',
-        key              => 't/sign-nopw-cert.pem',
-        cacert           => 't/cacert.pem',
-        org_name         => 'Test',
-        org_display_name => 'Test',
+
+
+        id     => 'Some entity ID',
+        cert   => 't/sign-nopw-cert.pem',
+        key    => 't/sign-nopw-cert.pem',
+        cacert => 't/cacert.pem',
+
+        org_name         => 'Net::SAML2::SP',
+        org_display_name => 'Net::SAML2::SP testsuite',
         org_contact      => 'test@example.com',
         org_url          => 'http://www.example.com',
-        slo_url_soap     => '/slo-soap',
+
+        url              => 'http://localhost:3000',
         slo_url_redirect => '/sls-redirect-response',
-        slo_url_post     => '/sls-post-response',
         acs_url_post     => '/consumer-post',
         acs_url_artifact => '/consumer-artifact',
-        org_name         => 'Net::SAML2 Saml2Test',
-        org_display_name => 'Saml2Test app for Net::SAML2',
-        org_contact      => 'saml2test@example.com',
         error_url        => '/error',
-        authnreq_signed  => '0',
-        want_assertions_signed => '0',
+
         @_,
     );
 }


### PR DESCRIPTION
Setup a bare minimum SP with just the defaults so it is easier to override
these defaults. Currently, in order to test this minimal thing we need to setup
the minimal thing while we can easily expand the caller to add their flavor.

Signed-off-by: Wesley Schwengle <wesley@opndev.io>