### PR TITLE
Add the index in the assertion_consumer_service

### DIFF
--- a/t/02-create-sp.t
+++ b/t/02-create-sp.t
@@ -261,6 +261,13 @@ use URN::OASIS::SAML2 qw(:bindings :urn);
             "... and has the correct index");
     }
 
+    my $default = $sp->get_default_assertion_service;
+    is($default->{Binding}, BINDING_HTTP_ARTIFACT,
+        "We found the default assertion service");
+    is($default->{Location}, 'https://foo.example.com/acs-http-artifact',
+        "... with the correct URI");
+    is($default->{index}, 2, "... and index");
+
     throws_ok(
         sub {
             my $sp = net_saml2_sp(


### PR DESCRIPTION
This way you can later ask the SP which one it is with the
`get_default_assertion_service` call. This is handy for those who configure the
SP and later on need to know the index of the assertion consumer service. Some
IdP's require this in the AuthnRequest and this way you can easily query the
SP.

Signed-off-by: Wesley Schwengle <wesley@opndev.io>