### PR TITLE
Fix contributers automaticly from git

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,11 @@
+Alessandro Ranellucci <aar@cpan.org>
+Ali Zia <ziali088@gmail.com>
+Chris Andrews <chris@nodnol.org>  <chrisandrews@venda.com>
+Jeff Fearn <jfearn@redhat.com>
+Mike Wisener <xmikew@cpan.org>  <mwisener@secureworks.com>
+Mike Wisener <xmikew@cpan.org> xmikew <github@32ths.com>
+Oskari Okko Ojala <okko@frantic.com>
+Peter Marschall <peter@adpm.de>
+Timothy Legge <timlegge@gmail.com>
+Wesley Schwengle <waterkip@cpan.org>  <wesleys@opperschaap.net>
+Wesley Schwengle <waterkip@cpan.org>  <wesley@opndev.io>

--- a/dist.ini
+++ b/dist.ini
@@ -7,16 +7,8 @@ license = Perl_5
 [Meta::Maintainers]
 maintainer = Timothy Legge <timlegge@gmail.com>
 
-[Meta::Contributors]
-contributor = Chris Andrews <chris@nodnol.org>
-contributor = Oskari Okko Ojala <okko@frantic.com>
-contributor = Peter Marschall <peter@adpm.de>
-contributor = Mike Wisener <xmikew@cpan.org>
-contributor = Jeff Fearn <jfearn@redhat.com>
-contributor = Alessandro Ranellucci <aar@cpan.org>
-contributor = Mike Wisener <mwisener@secureworks.com>, xmikew <github@32ths.com>
-contributor = xmikew <github@32ths.com>
-contributor = Timothy Legge <timlegge@gmail.com>
+[Git::Contributors]
+include_authors = 1
 
 [@Filter]
 bundle = @Basic


### PR DESCRIPTION
We can automaticly add contributors via the cvs system. Duplicates are removed
via a .mailmap entry

Signed-off-by: Wesley Schwengle <waterkip@cpan.org>