### PR TITLE
Set version in main module for downstream developers

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -81,6 +81,7 @@ first_version = 0.001       ; this is the default
 version_by_branch = 0       ; this is the default
 version_regexp  = ^(0.\d+)$   ; this is the default
 [OurPkgVersion]
+skip_main_module = 1
 [Git::Tag]
 tag_format  = %V       ; this is the default
 tag_message = %V       ; this is the default

--- a/lib/Net/SAML2.pm
+++ b/lib/Net/SAML2.pm
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 package Net::SAML2;
-# VERSION
+our $VERSION = "0.57";
 
 require 5.008_001;
 


### PR DESCRIPTION
By setting the version in lib/Net/SAML2.pm downstream developers can use a git
repo to install Net::SAML2 and still keep their dependencies correct. If a
module requires Net::SAML2 v0.56 and the version in git is not set, it cannot
validate the module version and it breaks the versioning check of for example
cpanminus. By setting the version in the main module we allow downstream users
to test/play with development versions of Net::SAML2.

Signed-off-by: Wesley Schwengle <waterkip@cpan.org>