### PR TITLE
Really make provider optional in Protocol::ArtifactResolve

### DIFF
--- a/lib/Net/SAML2/Protocol/ArtifactResolve.pm
+++ b/lib/Net/SAML2/Protocol/ArtifactResolve.pm
@@ -1,10 +1,9 @@
-use strict;
-use warnings;
 package Net::SAML2::Protocol::ArtifactResolve;
 # VERSION
 
 use Moose;
 use MooseX::Types::URI qw/ Uri /;
+use URN::OASIS::SAML2 qw(:urn);
 
 with 'Net::SAML2::Role::ProtocolMessage';
 
@@ -54,7 +53,12 @@ IdP's identity URI
 has 'issuer'      => (isa => 'Str', is => 'ro', required => 1);
 has 'destination' => (isa => 'Str', is => 'ro', required => 1);
 has 'artifact'    => (isa => 'Str', is => 'ro', required => 1);
-has 'provider'    => (isa => 'Str', is => 'ro', required => 0);
+has 'provider' => (
+    isa       => 'Str',
+    is        => 'ro',
+    required  => 0,
+    predicate => 'has_provider',
+);
 
 =head2 as_xml( )
 
@@ -66,8 +70,8 @@ sub as_xml {
     my ($self) = @_;
 
     my $x = XML::Generator->new(':pretty');
-    my $saml  = ['saml' => 'urn:oasis:names:tc:SAML:2.0:assertion'];
-    my $samlp = ['samlp' => 'urn:oasis:names:tc:SAML:2.0:protocol'];
+    my $saml  = ['saml' => URN_ASSERTION ];
+    my $samlp = ['samlp' => URN_PROTOCOL ];
 
     $x->xml(
         $x->ArtifactResolve(
@@ -75,7 +79,9 @@ sub as_xml {
             { ID => $self->id,
               IssueInstant => $self->issue_instant,
               Destination => $self->destination,
-              ProviderName => $self->provider || "My SP's human readable name.",
+              $self->has_provider ? (
+                  ProviderName => $self->provider,
+              ) : (),
               Version => '2.0' },
             $x->Issuer(
                 $saml,

--- a/t/10-artifact-resolve.t
+++ b/t/10-artifact-resolve.t
@@ -4,6 +4,7 @@ use Test::Lib;
 use Test::Net::SAML2;
 
 use Net::SAML2::Protocol::ArtifactResolve;
+use URN::OASIS::SAML2 qw(:urn);
 
 my $ar = Net::SAML2::Protocol::ArtifactResolve->new(
     issuer      => 'http://some/sp',
@@ -15,20 +16,22 @@ my $ar = Net::SAML2::Protocol::ArtifactResolve->new(
 
 isa_ok($ar, 'Net::SAML2::Protocol::ArtifactResolve');
 
-my $override
-    = Sub::Override->override(
-    'Net::SAML2::Protocol::ArtifactResolve::issue_instant' =>
-        sub { return 'myissueinstant' });
+my $override = Sub::Override->override(
+    'Net::SAML2::Protocol::ArtifactResolve::issue_instant' => sub {
+        return 'myissueinstant';
+    }
+);
 
 $override->override(
-    'Net::SAML2::Protocol::ArtifactResolve::id' => sub { return 'myid' });
+    'Net::SAML2::Protocol::ArtifactResolve::id' => sub { return 'myid' }
+);
 
 my $xml = $ar->as_xml;
 
 my $xp = get_xpath(
     $xml,
-    samlp => 'urn:oasis:names:tc:SAML:2.0:protocol',
-    saml  => 'urn:oasis:names:tc:SAML:2.0:assertion',
+    samlp => URN_PROTOCOL,
+    saml  => URN_ASSERTION,
 );
 
 test_xml_attribute_ok($xp, '/samlp:ArtifactResolve/@ID', 'myid');
@@ -36,8 +39,28 @@ test_xml_attribute_ok($xp, '/samlp:ArtifactResolve/@IssueInstant',
     'myissueinstant');
 
 test_xml_value_ok($xp, '/samlp:ArtifactResolve/samlp:Artifact',
-    'some-artifact',);
+    'some-artifact');
 
 test_xml_attribute_ok($xp, '/samlp:ArtifactResolve/@ProviderName',
-    'Net-SAML2 Test',);
+    'Net-SAML2 Test');
+
+{
+    my $ar = Net::SAML2::Protocol::ArtifactResolve->new(
+        issuer      => 'http://some/sp',
+        destination => 'http://some/idp',
+        artifact    => 'some-artifact',
+    );
+
+    my $xml = $ar->as_xml;
+    my $xp = get_xpath(
+        $xml,
+        samlp => URN_PROTOCOL,
+        saml  => URN_ASSERTION,
+    );
+
+    my $nodes = $xp->findnodes('/samlp:ArtifactResolve/@ProviderName');
+    is($nodes->size, 0, "We don't have a provider name");
+
+}
+
 done_testing;


### PR DESCRIPTION
The previous incarnation supplied a default when as_xml was called. Not all
code requires a provider, so we don't use it if nothing has been provided by
the caller.

Signed-off-by: Wesley Schwengle <waterkip@cpan.org>