### PR TITLE
Add builder to Binding::SOAP for LWP::UA

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,9 @@ jobs:
           echo '35c896266e4257793387ba22d5d76078  pari-2.3.4.tar.gz' | md5sum -c - ;
           tar zxf pari-2.3.4.tar.gz;
           cd - ;
-          cpanm Math::Pari Moose;
+          cpanm Math::Pari;
+          cpanm Package::DeprecationManager;
+          cpanm Moose;
           cpanm --installdeps . ;
       - name: Build Module
         run: |

--- a/lib/Net/SAML2/Binding/SOAP.pm
+++ b/lib/Net/SAML2/Binding/SOAP.pm
@@ -45,6 +45,8 @@ Arguments:
 =item B<ua>
 
 (optional) a LWP::UserAgent-compatible UA
+You can build the user agent to your liking when extending this class by
+overriding C<build_user_agent>
 
 =item B<url>
 
@@ -73,9 +75,19 @@ the CA for the SAML CoT
 has 'ua' => (
     isa      => 'Object',
     is       => 'ro',
-    required => 1,
-    default  => sub { LWP::UserAgent->new }
+    lazy     => 1,
+    builder  => 'build_user_agent',
 );
+
+=head2 build_user_agent
+
+Builder for the user agent
+
+=cut
+
+sub build_user_agent {
+    return LWP::UserAgent->new();
+}
 
 has 'url'      => (isa => Uri, is => 'ro', required => 1, coerce => 1);
 has 'key'      => (isa => 'Str', is => 'ro', required => 1);


### PR DESCRIPTION
This way one can extend/override the builder for the UA object and makes it
easier to extend the Binding.

Signed-off-by: Wesley Schwengle <waterkip@cpan.org>