### PR TITLE
BREAKING CHANGES: Verifying XML and trust anchors on SAML responses

### DIFF
--- a/lib/Net/SAML2/Binding/POST.pm
+++ b/lib/Net/SAML2/Binding/POST.pm
@@ -28,6 +28,8 @@ use Net::SAML2::XML::Sig;
 use MIME::Base64 qw/ decode_base64 /;
 use Crypt::OpenSSL::Verify;
 
+with 'Net::SAML2::Role::VerifyXML';
+
 =head2 new( )
 
 Constructor. Returns an instance of the POST binding.
@@ -59,27 +61,19 @@ sub handle_response {
 
     # unpack and check the signature
     my $xml = decode_base64($response);
-    my $xml_opts = { x509 => 1 };
-    $xml_opts->{ cert_text } = $self->cert_text if ($self->cert_text);
-    $xml_opts->{ exclusive } = 1;
-    $xml_opts->{ no_xml_declaration } = 1;
-    my $x = Net::SAML2::XML::Sig->new($xml_opts);
-    my $ret = $x->verify($xml);
-    die "signature check failed" unless $ret;
 
-    if ($self->cacert) {
-        my $cert = $x->signer_cert
-            or die "Certificate not provided and not in SAML Response, cannot validate";
+    $self->verify_xml(
+        $xml,
+        no_xml_declaration => 1,
+        $self->cert_text ? (
+            cert_text => $self->cert_text
+        ) : (),
+        $self->cacert ? (
+            cacert => $self->cacert
+        ) : (),
 
-        my $ca = Crypt::OpenSSL::Verify->new($self->cacert, { strict_certs => 0, });
-        if ($ca->verify($cert)) {
-            return sprintf("%s (verified)", $cert->subject);
-        } else {
-            return 0;
-        }
-    }
-
-    return 1;
+    );
+    return $xml;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Net/SAML2/Binding/SOAP.pm
+++ b/lib/Net/SAML2/Binding/SOAP.pm
@@ -94,7 +94,7 @@ has 'url'      => (isa => Uri, is => 'ro', required => 1, coerce => 1);
 has 'key'      => (isa => 'Str', is => 'ro', required => 1);
 has 'cert'     => (isa => 'Str', is => 'ro', required => 1);
 has 'idp_cert' => (isa => 'Str', is => 'ro', required => 1);
-has 'cacert'   => (isa => 'Str', is => 'ro', required => 1);
+has 'cacert'   => (isa => 'Str', is => 'ro', required => 0);
 
 =head2 request( $message )
 

--- a/lib/Net/SAML2/Role/VerifyXML.pm
+++ b/lib/Net/SAML2/Role/VerifyXML.pm
@@ -4,6 +4,9 @@ use Moose::Role;
 
 use Net::SAML2::XML::Sig;
 use Crypt::OpenSSL::Verify;
+use Crypt::OpenSSL::X509;
+use Carp qw(croak);
+use List::Util qw(none);
 
 # ABSTRACT: A role to verify the SAML response XML
 
@@ -41,9 +44,18 @@ use Crypt::OpenSSL::Verify;
         # Most of these options are passed to Net::SAML2::XML::Sig, except for the
         # cacert
         # Most options are optional
-        cacert    => $self->cacert,
         cert_text => $self->cert,
         no_xml_declaration => 1,
+
+        # Used for a trust model, if lacking, everything is trusted
+        cacert  => $self->cacert,
+        # or check specific certificates based on subject/issuer or issuer hash
+        anchors => {
+            # one of the following is allowed
+            subject     => ["subject a",     "subject b"],
+            issuer      => ["Issuer A",      "Issuer B"],
+            issuer_hash => ["Issuer A hash", "Issuer B hash"],
+        },
     );
 
 =cut
@@ -54,6 +66,7 @@ sub verify_xml {
     my %args = @_;
 
     my $cacert   = delete $args{cacert};
+    my $anchors  = delete $args{anchors};
 
     my $x = Net::SAML2::XML::Sig->new({
         x509      => 1,
@@ -61,16 +74,45 @@ sub verify_xml {
         %args,
     });
 
-    die "XML signature check failed\n" unless $x->verify($xml);
+    croak("XML signature check failed") unless $x->verify($xml);
 
-    return unless $cacert;
+    if (!$anchors && !$cacert) {
+        return 1;
+    }
 
     my $cert = $x->signer_cert
         or die "Certificate not provided in SAML Response, cannot validate\n";
 
-    my $ca = Crypt::OpenSSL::Verify->new($cacert, { strict_certs => 0 });
-    return if $ca->verify($cert);
-    die "Could not verify CA certificate!\n";
+    if ($cacert) {
+        my $ca = Crypt::OpenSSL::Verify->new($cacert, { strict_certs => 0 });
+        eval { $ca->verify($cert) };
+        if ($@) {
+            croak("Could not verify CA certificate: $@");
+        }
+    }
+
+    return 1 if !$anchors;
+
+    if (ref $anchors ne 'HASH') {
+        croak("Unable to verify anchor trust");
+    }
+
+    my ($key) = keys %$anchors;
+    if (none { $key eq $_ } qw(subject issuer issuer_hash)) {
+        croak("Unable to verify anchor trust, requires subject, issuer or issuer_hash");
+    }
+
+    my $got = $cert->$key;
+    my $want = $anchors->{$key};
+    if (!ref $want) {
+        $want = [ $want ];
+    }
+
+    if (none { $_ eq $got } @$want) {
+        croak("Could not verify trust anchors of certificate!");
+    }
+    return 1;
+
 }
 
 

--- a/lib/Net/SAML2/Role/VerifyXML.pm
+++ b/lib/Net/SAML2/Role/VerifyXML.pm
@@ -1,0 +1,80 @@
+package Net::SAML2::Role::VerifyXML;
+use Moose::Role;
+# VERSION
+
+use Net::SAML2::XML::Sig;
+use Crypt::OpenSSL::Verify;
+
+# ABSTRACT: A role to verify the SAML response XML
+
+=head1 DESCRIPTION
+
+=head1 SYNOPSIS
+
+    use Net::SAML2::Some::Module;
+
+    use Moose;
+    with 'Net::SAML2::Role::VerifyXML';
+
+    sub do_something_with_xml {
+        my $self = shift;
+        my $xml  = shift;
+
+        $self->verify_xml($xml,
+            # Most of these options are passed to Net::SAML2::XML::Sig, except for the
+            # cacert
+            # Most options are optional
+            cacert    => $self->cacert,
+            cert_text => $self->cert,
+            no_xml_declaration => 1,
+        );
+    }
+
+=cut
+
+
+=head1 METHODS
+
+=head2 verify_xml($xml, %args)
+
+    $self->verify_xml($xml,
+        # Most of these options are passed to Net::SAML2::XML::Sig, except for the
+        # cacert
+        # Most options are optional
+        cacert    => $self->cacert,
+        cert_text => $self->cert,
+        no_xml_declaration => 1,
+    );
+
+=cut
+
+sub verify_xml {
+    my $self = shift;
+    my $xml  = shift;
+    my %args = @_;
+
+    my $cacert   = delete $args{cacert};
+
+    my $x = Net::SAML2::XML::Sig->new({
+        x509      => 1,
+        exclusive => 1,
+        %args,
+    });
+
+    die "XML signature check failed\n" unless $x->verify($xml);
+
+    return unless $cacert;
+
+    my $cert = $x->signer_cert
+        or die "Certificate not provided in SAML Response, cannot validate\n";
+
+    my $ca = Crypt::OpenSSL::Verify->new($cacert, { strict_certs => 0 });
+    return if $ca->verify($cert);
+    die "Could not verify CA certificate!\n";
+}
+
+
+1;
+
+__END__
+

--- a/lib/Net/SAML2/SP.pm
+++ b/lib/Net/SAML2/SP.pm
@@ -413,17 +413,13 @@ XXX UA
 sub soap_binding {
     my ($self, $ua, $idp_url, $idp_cert) = @_;
 
-    if (!$self->has_cacert) {
-        croak("Unable to create SOAP binding, no CA certificate provided");
-    }
-
     return Net::SAML2::Binding::SOAP->new(
         ua       => $ua,
         key      => $self->key,
         cert     => $self->cert,
         url      => $idp_url,
         idp_cert => $idp_cert,
-        cacert   => $self->cacert,
+        $self->has_cacert ? (cacert => $self->cacert) : (),
     );
 }
 

--- a/lib/Net/SAML2/Util.pm
+++ b/lib/Net/SAML2/Util.pm
@@ -5,7 +5,7 @@ package Net::SAML2::Util;
 
 use Crypt::OpenSSL::Random qw(random_pseudo_bytes);
 
-# ABSTRACT: Utility functions for Net:SAML2
+# ABSTRACT: Utility functions for Net::SAML2
 
 use Exporter qw(import);
 

--- a/lib/Net/SAML2/XML/Util.pm
+++ b/lib/Net/SAML2/XML/Util.pm
@@ -44,10 +44,11 @@ sub no_comments {
 
     # Remove comments from XML to mitigate XML comment auth bypass
     my $dom = XML::LibXML->load_xml(
-                    string => $xml,
-                    no_network => 1,
-                    load_ext_dtd => 0,
-                    expand_entities => 0 );
+        string          => $xml,
+        no_network      => 1,
+        load_ext_dtd    => 0,
+        expand_entities => 0
+    );
 
     for my $comment_node ($dom->findnodes('//comment()')) {
         $comment_node->parentNode->removeChild($comment_node);

--- a/t/04-response.t
+++ b/t/04-response.t
@@ -67,23 +67,19 @@ my $sp = net_saml2_sp();
 
 my $post = $sp->post_binding;
 
-my $subject;
+my $response_xml;
 
 lives_ok(
     sub {
-        $subject = $post->handle_response($response);
+        $response_xml = $post->handle_response($response);
     },
     '$sp->handle_response works'
 );
 
 
-ok(defined $subject, "->handle response verified something");
-like($subject, qr/verified/, "Matches the verified string");
+is($xml, $response_xml, "We have the response XML as XML");
 
-## TODO: Move to t/03-assertion
-my $assertion_xml = decode_base64($response);
-my $assertion = Net::SAML2::Protocol::Assertion->new_from_xml(xml => $xml);
-
+my $assertion = Net::SAML2::Protocol::Assertion->new_from_xml(xml => $response_xml);
 isa_ok($assertion, 'Net::SAML2::Protocol::Assertion');
 
 done_testing;

--- a/t/05-soap-binding.t
+++ b/t/05-soap-binding.t
@@ -4,6 +4,8 @@ use Test::Lib;
 use Test::Net::SAML2;
 
 use Net::SAML2::IdP;
+use Net::SAML2::Binding::SOAP;
+use Test::Mock::One;
 
 use LWP::UserAgent;
 
@@ -40,7 +42,7 @@ my $request_xml = $request->as_xml;
 my $xp = get_xpath($request_xml);
 isa_ok($xp, "XML::LibXML::XPathContext");
 
-my $ua = LWP::UserAgent->new;
+my $ua   = LWP::UserAgent->new;
 my $soap = $sp->soap_binding($ua, $slo_url, $idp_cert);
 isa_ok($soap, "Net::SAML2::Binding::SOAP");
 
@@ -64,5 +66,65 @@ is($soaped_request->session, $request->session,
     "SOAP session equals request session");
 is($soaped_request->nameid, $request->nameid,
     "SOAP nameid equals request nameid");
+
+{
+    # Testing trust anchors of SAML
+    # You can set various trust anchors of SAML so the response is checked
+    # against some kind of anchor.
+    my %anchors = (
+        subject     => [qw(foo bar)],
+        issuer      => 'Net::SAML2',
+        issuer_hash => [
+            'f1d2d2f924e986ac86fdf7b36c94bcdf32beec15',
+            'e242ed3bffccdf271b7fbaf34ed72d089537b42f'
+        ],
+    );
+
+    my $xml      = "<xml></xml>";
+    my $override = Sub::Override->new(
+        'Net::SAML2::Binding::SOAP::_get_saml_from_soap' => sub {
+            return $xml;
+        },
+    );
+    $override->override(
+        'XML::Sig::new' => sub {
+            return Test::Mock::One->new(
+                subject     => 'foo',
+                issuer      => 'Net::SAML2',
+                issuer_hash => 'f1d2d2f924e986ac86fdf7b36c94bcdf32beec15',
+            );
+        }
+    );
+
+    foreach (keys %anchors) {
+        my $soap = Net::SAML2::Binding::SOAP->new(
+            url      => 'https://example.com/auth/saml',
+            key      => $sp->key,
+            cert     => $sp->cert,
+            idp_cert => $idp_cert,
+            anchors  => { $_ => $anchors{$_} }
+        );
+        isa_ok($soap, "Net::SAML2::Binding::SOAP");
+
+        is($soap->handle_response('here be soap'),
+            "<xml></xml>", "We got our XML, so we are verified");
+    }
+
+    my $soap = Net::SAML2::Binding::SOAP->new(
+        url      => 'https://example.com/auth/saml',
+        key      => $sp->key,
+        cert     => $sp->cert,
+        idp_cert => $idp_cert,
+        anchors  => { subject => 'testsuite failure expected' }
+    );
+
+    throws_ok(
+        sub {
+            $soap->handle_response('here be failure');
+        },
+        qr/Could not verify trust anchors of certificate!/,
+        "We cannot trust the anchor"
+    )
+}
 
 done_testing;

--- a/t/05-soap-binding.t
+++ b/t/05-soap-binding.t
@@ -50,12 +50,7 @@ my $soap_req = $soap->create_soap_envelope($request_xml);
 $xp = get_xpath($soap_req);
 isa_ok($xp, "XML::LibXML::XPathContext");
 
-my ($subject, $xml) = $soap->handle_request($soap_req);
-is(
-    $subject,
-    'C=US, O=local, OU=ct, CN=saml, emailAddress=saml@ct.local',
-    "Subject is ok"
-);
+my $xml = $soap->handle_request($soap_req);
 like($xml, qr/\Q<samlp:LogoutRequest\E/, "Logout XML found");
 $xp = get_xpath($xml);
 isa_ok($xp, "XML::LibXML::XPathContext");


### PR DESCRIPTION
The 48e37f57f73ed262c70fd3e843680644332c36c0 changeset implements a couple of breaking changes in regards to how handle_response of Net::SAML2::Binding::SOAP and Net::SAML2::Binding::POST works. We now return the XML of the request so callers can do something with the response. In previous versions this code returned an array of the certificate subject and the XML. However, depending on the how, the subject was a scalar 1 or the DN of the signing certificate. This was confusing to me. I looked into some SAML documentation to figure out why this was done previously.

SAML uses a concept called trust anchors where you can say "I trust this party because of $reasons". These trust anchors can be the issuing party, the DN of the certificate, etc. The previous code implemented a partial solution to this, it just said that the trust anchor was the DN of the certificate of the signer. To support the concept of trust anchors we can now inject these anchors in the Binding::SOAP object. This is implemented in 6e0fa64e6f50c5709fcfb0232f631045151c43d2.

Than there is commit 3d2c9aa084e296896fdfbc83891e6a0218709f46 which makes the CA certificate for the SOAP binding optional and gives the caller total control over how the response is verified: either by cacert, by a trust anchor, or not at all (besides the check that the message is signed by the cert in the XML).