### PR TITLE
nameid_format cannot be a zero length string

### DIFF
--- a/lib/Net/SAML2/SP.pm
+++ b/lib/Net/SAML2/SP.pm
@@ -303,7 +303,7 @@ sub logout_request {
         issuer        => $self->id,
         destination   => $destination,
         nameid        => $nameid,
-        nameid_format => $nameid_format,
+        $nameid_format ? (nameid_format => $nameid_format) : (),
         session       => $session,
     );
 

--- a/xt/testapp/lib/Saml2Test.pm
+++ b/xt/testapp/lib/Saml2Test.pm
@@ -92,7 +92,7 @@ get '/logout-redirect' => sub {
     my $logoutreq = $sp->logout_request(
         $idp->slo_url('urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'),
         params->{nameid},
-        $idp->format,
+        $idp->format || undef,
         params->{session}
     )->as_xml;
 


### PR DESCRIPTION
Some testing revealed that the nameid_format cannot be passed as an empty string.  Probably a better way to do this but if this is fine I will merge and release a trial