### PR TITLE
Make params optional in Binding::Redirect for SAMLResponse

### DIFF
--- a/lib/Net/SAML2/Binding/Redirect.pm
+++ b/lib/Net/SAML2/Binding/Redirect.pm
@@ -6,6 +6,7 @@ package Net::SAML2::Binding::Redirect;
 use Moose;
 use MooseX::Types::URI qw/ Uri /;
 use Net::SAML2::Types qw(signingAlgorithm SAMLRequestType);
+use Carp qw(croak);
 
 # ABSTRACT: Net::SAML2::Binding::Redirect - HTTP Redirect binding for SAML
 
@@ -96,9 +97,9 @@ The double encoding requires it to be decoded prior to processing.
 
 =cut
 
-has 'key'  => (isa => 'Str', is => 'ro', required => 1);
 has 'cert' => (isa => 'Str', is => 'ro', required => 1);
-has 'url'  => (isa => Uri, is => 'ro', required => 1, coerce => 1);
+has 'url'  => (isa => Uri, is => 'ro', required => 0, coerce => 1, predicate => 'has_url');
+has 'key'  => (isa => 'Str', is => 'ro', required => 0, predicate => 'has_key');
 
 has 'param' => (
     isa      => SAMLRequestType,
@@ -127,6 +128,16 @@ has 'sls_double_encoded_response' => (
     required => 0,
     default  => 0
 );
+
+sub BUILD {
+    my $self = shift;
+
+    if ($self->param eq 'SAMLRequest') {
+        croak("Need to have an URL specified") unless $self->has_url;
+        croak("Need to have a key specified") unless $self->has_key;
+    }
+    # other params don't need to have these per-se
+}
 
 =head2 sign( $request, $relaystate )
 

--- a/t/06-redirect-binding.t
+++ b/t/06-redirect-binding.t
@@ -4,6 +4,7 @@ use Test::Lib;
 use Test::Net::SAML2;
 
 use Net::SAML2::IdP;
+use Net::SAML2::Binding::Redirect;
 
 my $sp = net_saml2_sp();
 
@@ -50,5 +51,38 @@ test_xml_attribute_ok($xp, '/saml2p:AuthnRequest/@ID', qr/^NETSAML2_/,
     "Found a requestID");
 
 is($relaystate, 'http://return/url', "Relay state shows correct uri");
+
+lives_ok(
+    sub {
+        my $binding = Net::SAML2::Binding::Redirect->new(
+            cert  => $sp->cert,
+            param => 'SAMLResponse',
+        );
+        isa_ok($binding, "Net::SAML2::Binding::Redirect");
+    },
+    "We can create a binding redirect without key/url for verification purposes"
+);
+
+throws_ok(
+    sub {
+        Net::SAML2::Binding::Redirect->new(
+            cert  => $sp->cert,
+            key   => $sp->key,
+        );
+    },
+    qr/Need to have an URL specified/,
+    "Need an URL for SAMLRequest"
+);
+
+throws_ok(
+    sub {
+        Net::SAML2::Binding::Redirect->new(
+            cert  => $sp->cert,
+            url   => 'https://foo.example.com',
+        );
+    },
+    qr/Need to have a key specified/,
+    "Need a key for SAMLRequest"
+);
 
 done_testing;


### PR DESCRIPTION
Signed-off-by: Wesley Schwengle <waterkip@cpan.org>