### PR TITLE
Make attributes in NameID optional

### DIFF
--- a/lib/Net/SAML2/Protocol/LogoutRequest.pm
+++ b/lib/Net/SAML2/Protocol/LogoutRequest.pm
@@ -1,5 +1,3 @@
-use strict;
-use warnings;
 package Net::SAML2::Protocol::LogoutRequest;
 # VERSION
 
@@ -8,6 +6,7 @@ use MooseX::Types::Common::String qw/ NonEmptySimpleStr /;
 use MooseX::Types::URI qw/ Uri /;
 use Net::SAML2::XML::Util qw/ no_comments /;
 use XML::Generator;
+use URN::OASIS::SAML2 qw(:urn);
 
 with 'Net::SAML2::Role::ProtocolMessage';
 
@@ -63,8 +62,48 @@ sent regardless
 
 has 'session'       => (isa => NonEmptySimpleStr, is => 'ro', required => 1);
 has 'nameid'        => (isa => NonEmptySimpleStr, is => 'ro', required => 1);
-has 'nameid_format' => (isa => NonEmptySimpleStr, is => 'ro', required => 0);
-has 'destination'   => (isa => NonEmptySimpleStr, is => 'ro', required => 0);
+has 'nameid_format' => (
+    isa       => NonEmptySimpleStr,
+    is        => 'ro',
+    required  => 0,
+    predicate => 'has_nameid_format'
+);
+has 'destination' => (
+    isa       => NonEmptySimpleStr,
+    is        => 'ro',
+    required  => 0,
+    predicate => 'has_destination'
+);
+
+has sp_provided_id => (
+    isa       => NonEmptySimpleStr,
+    is        => 'ro',
+    required  => 0,
+    predicate => 'has_sp_provided_id'
+);
+
+has affiliation_group_id => (
+    isa       => NonEmptySimpleStr,
+    is        => 'ro',
+    required  => 0,
+    predicate => 'has_affiliation_group_id'
+);
+
+has include_name_qualifier =>
+    (isa => 'Bool', is => 'ro', required => 0, default => 0);
+
+around BUILDARGS => sub {
+    my $orig = shift;
+    my $self = shift;
+    my %args = @_;
+
+    if ($args{nameid_format} && $args{nameid_format} eq 'urn:oasis:names:tc:SAML:2.0:nameidformat:persistent') {
+        $args{include_name_qualifier} = 1;
+    }
+
+    return $self->$orig(%args);
+};
+
 
 =head2 new_from_xml( ... )
 
@@ -88,25 +127,27 @@ sub new_from_xml {
     my $dom = no_comments($args{xml});
 
     my $xpath = XML::LibXML::XPathContext->new($dom);
-    $xpath->registerNs('saml', 'urn:oasis:names:tc:SAML:2.0:assertion');
-    $xpath->registerNs('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');
+    $xpath->registerNs('saml',  URN_ASSERTION);
+    $xpath->registerNs('samlp', URN_PROTOCOL);
 
     my %params = (
-        id            => $xpath->findvalue('/samlp:LogoutRequest/@ID'),
-        session       => $xpath->findvalue('/samlp:LogoutRequest/samlp:SessionIndex'),
-        issuer        => $xpath->findvalue('/samlp:LogoutRequest/saml:Issuer'),
-        nameid        => $xpath->findvalue('/samlp:LogoutRequest/saml:NameID'),
-        destination   => $xpath->findvalue('/samlp:LogoutRequest/@Destination'),
+        id          => $xpath->findvalue('/samlp:LogoutRequest/@ID'),
+        session     => $xpath->findvalue('/samlp:LogoutRequest/samlp:SessionIndex'),
+        issuer      => $xpath->findvalue('/samlp:LogoutRequest/saml:Issuer'),
+        nameid      => $xpath->findvalue('/samlp:LogoutRequest/saml:NameID'),
+        destination => $xpath->findvalue('/samlp:LogoutRequest/@Destination'),
     );
 
-    my $nameid_format = $xpath->findvalue('/samlp:LogoutRequest/saml:NameID/@Format');
-    if ( $nameid_format ne '' ) { $params{nameid_format} = $nameid_format; }
+    my $nameid_format
+        = $xpath->findvalue('/samlp:LogoutRequest/saml:NameID/@Format');
 
-    my $self = $class->new(
-        %params
-    );
+    $params{nameid_format} = $nameid_format
+        if NonEmptySimpleStr->check($nameid_format);
 
-    return $self;
+    $params{include_name_qualifier} = $args{include_name_qualifier}
+        if $args{include_name_qualifier};
+
+    return $class->new(%params);
 }
 
 =head2 as_xml( )
@@ -116,34 +157,47 @@ Returns the LogoutRequest as XML.
 =cut
 
 sub as_xml {
-    my ($self) = @_;
+    my $self = shift;
 
-    my $x = XML::Generator->new(':pretty');
-    my $saml  = ['saml' => 'urn:oasis:names:tc:SAML:2.0:assertion'];
-    my $samlp = ['samlp' => 'urn:oasis:names:tc:SAML:2.0:protocol'];
+    my $x     = XML::Generator->new(':pretty=0');
+    my $saml  = ['saml'  => URN_ASSERTION];
+    my $samlp = ['samlp' => URN_PROTOCOL];
+
 
     $x->xml(
         $x->LogoutRequest(
             $samlp,
-            { ID => $self->id,
-              IssueInstant => $self->issue_instant,
-              Destination => $self->destination,
-              Version => '2.0' },
-            $x->Issuer(
-                $saml,
-                $self->issuer,
-            ),
+            {
+                ID           => $self->id,
+                IssueInstant => $self->issue_instant,
+                $self->has_destination
+                ? (Destination => $self->destination)
+                : (),
+                Version => '2.0'
+            },
+            $x->Issuer($saml, $self->issuer),
             $x->NameID(
                 $saml,
-                { Format => $self->nameid_format,
-                  NameQualifier => $self->destination,
-                  SPNameQualifier => $self->issuer },
-                $self->nameid,
+                {
+                    $self->has_nameid_format
+                    ? (Format => $self->nameid_format)
+                    : (),
+                    $self->has_sp_provided_id ? (
+                        SPProvidedID => $self->sp_provided_id
+                    ) : (),
+                    $self->include_name_qualifier
+                    ? (
+                        $self->has_destination
+                        ? (NameQualifier => $self->destination)
+                        : (),
+                        SPNameQualifier =>
+                        $self->has_affiliation_group_id ? $self->affiliation_group_id : $self->issuer
+                        )
+                    : (),
+                },
+                $self->nameid
             ),
-            $x->SessionIndex(
-                $samlp,
-                $self->session,
-            ),
+            $x->SessionIndex($samlp, $self->session),
         )
     );
 }

--- a/lib/Net/SAML2/SP.pm
+++ b/lib/Net/SAML2/SP.pm
@@ -10,6 +10,7 @@ use Crypt::OpenSSL::X509;
 use Digest::MD5 ();
 use List::Util qw(first none);
 use MooseX::Types::URI qw/ Uri /;
+use MooseX::Types::Common::String qw/ NonEmptySimpleStr /;
 use Net::SAML2::Binding::POST;
 use Net::SAML2::Binding::Redirect;
 use Net::SAML2::Binding::SOAP;
@@ -300,11 +301,13 @@ sub logout_request {
     my ($self, $destination, $nameid, $nameid_format, $session) = @_;
 
     my $logout_req = Net::SAML2::Protocol::LogoutRequest->new(
-        issuer        => $self->id,
-        destination   => $destination,
-        nameid        => $nameid,
-        $nameid_format ? (nameid_format => $nameid_format) : (),
-        session       => $session,
+        issuer      => $self->id,
+        destination => $destination,
+        nameid      => $nameid,
+        session     => $session,
+        NonEmptySimpleStr->check($nameid_format)
+            ? (nameid_format => $nameid_format)
+            : (),
     );
 
     return $logout_req;

--- a/t/07-logout-request.t
+++ b/t/07-logout-request.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::Lib;
 use Test::Net::SAML2;
+use URN::OASIS::SAML2 qw(:urn);
 
 use Net::SAML2::Protocol::LogoutRequest;
 
@@ -26,15 +27,60 @@ my $xml = $lor->as_xml;
 
 my $xpath = get_xpath(
     $xml,
-    samlp => 'urn:oasis:names:tc:SAML:2.0:protocol',
-    saml  => 'urn:oasis:names:tc:SAML:2.0:assertion',
+    samlp => URN_PROTOCOL,
+    saml  => URN_ASSERTION,
 );
 
 isa_ok($xpath, 'XML::LibXML::XPathContext');
 
 test_xml_attribute_ok($xpath, '/samlp:LogoutRequest/@ID', qr/^NETSAML2_/);
 test_xml_attribute_ok($xpath, '/samlp:LogoutRequest/@IssueInstant', 'foo');
-test_xml_attribute_ok($xpath, '/samlp:LogoutRequest/saml:NameID/@Format',
-    $args{nameid_format});
+
+my $name_id = get_single_node_ok($xpath, '/samlp:LogoutRequest/saml:NameID');
+is($name_id->getAttribute('Format'), $args{nameid_format});
+
+foreach (qw(NameQualifier SPNameQualifier SPProvidedID)) {
+    is(
+        $name_id->getAttribute($_),
+        undef,
+        "We don't have $_ as an attribute in the nameid"
+    );
+}
+
+{
+    my $lor = Net::SAML2::Protocol::LogoutRequest->new(%args,
+        sp_provided_id => "Some provided ID");
+    my $xml = $lor->as_xml;
+
+    my $xpath = get_xpath(
+        $xml,
+        samlp => URN_PROTOCOL,
+        saml  => URN_ASSERTION,
+    );
+    my $name_id = get_single_node_ok($xpath, '/samlp:LogoutRequest/saml:NameID');
+    is(
+        $name_id->getAttribute('SPProvidedID'),
+        "Some provided ID",
+        "We have the SP provided ID"
+    );
+}
+
+{
+    my $lor = Net::SAML2::Protocol::LogoutRequest->new(%args,
+        include_name_qualifier => 1);
+    my $xml = $lor->as_xml;
+
+    my $xpath = get_xpath(
+        $xml,
+        samlp => URN_PROTOCOL,
+        saml  => URN_ASSERTION,
+    );
+    my $name_id = get_single_node_ok($xpath, '/samlp:LogoutRequest/saml:NameID');
+    is($name_id->getAttribute('SPNameQualifier'),
+        $args{issuer}, "We the SPNameQualifier");
+    is($name_id->getAttribute('NameQualifier'),
+        $args{destination}, ".. and the NameQualifier");
+}
+
 
 done_testing;


### PR DESCRIPTION
The Format attribute in NameID will only be set if there is a nameid format
configured. The NameQualifier and SPNameQualifier are only set when this is
configured by setting `include_name_qualifier`. This is because the SAML spec
says:

> The NameQualifier and SPNameQualifier attributes SHOULD be omitted unless the
> element or format explicitly defines their use and semantics.

The SAML spec also says that if the NameID Format is
`urn:oasis:names:tc:SAML:2.0:nameidformat:persistent` tese two options must be
set. We support this. If there is an affiliation_group_id than we use that
instead of the destination ID because of the same spec.

> In any case, the <saml:NameID> content in the request and its associated
> SPProvidedID attribute MUST contain the most recent name identifier
> information established between the providers for the principal.
>
> In the case of an identifier with a Format of
> urn:oasis:names:tc:SAML:2.0:nameidformat:persistent, the NameQualifier
> attribute MUST contain the unique identifier of the identity provider that
> created the identifier. If the identifier was established between the
> identity provider and an affiliation group of which the service provider is a
> member, then the SPNameQualifier attribute MUST contain the unique identifier
> of the affiliation group. Otherwise, it MUST contain the unique identifier of
> the service provider. These attributes MAY be omitted if they would otherwise
> match the value of the containing protocol message's <Issuer> element, but
> this is NOT RECOMMENDED due to the opportunity for confusion.

For more information see:
http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf

Signed-off-by: Wesley Schwengle <waterkip@cpan.org>