### PR TITLE
Add missing POD for nameid, nameid_format in Protocol::Assertion

### DIFF
--- a/lib/Net/SAML2/Protocol/Assertion.pm
+++ b/lib/Net/SAML2/Protocol/Assertion.pm
@@ -188,10 +188,22 @@ sub name {
     return $self->attributes->{CN}->[0];
 }
 
+=head2 nameid
+
+Returns the NameID
+
+=cut
+
 sub nameid {
     my $self = shift;
     return $self->nameid_object->textContent;
 }
+
+=head2 nameid
+
+Returns the NameID Format
+
+=cut
 
 sub nameid_format {
     my $self = shift;


### PR DESCRIPTION
Signed-off-by: Wesley Schwengle <waterkip@cpan.org>