### PR TITLE
Fix author tests with dzil

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,0 +1,6 @@
+[TestingAndDebugging::RequireUseStrict]
+equivalent_modules = Moose Test::Net::SAML2
+
+[TestingAndDebugging::RequireUseWarnings]
+equivalent_modules = Moose Test::Net::SAML2
+

--- a/lib/Net/SAML2/Binding/Redirect.pm
+++ b/lib/Net/SAML2/Binding/Redirect.pm
@@ -129,6 +129,10 @@ has 'sls_double_encoded_response' => (
     default  => 0
 );
 
+=for Pod::Coverage BUILD
+
+=cut
+
 sub BUILD {
     my $self = shift;
 

--- a/lib/Net/SAML2/Protocol/ArtifactResolve.pm
+++ b/lib/Net/SAML2/Protocol/ArtifactResolve.pm
@@ -1,7 +1,7 @@
 package Net::SAML2::Protocol::ArtifactResolve;
+use Moose;
 # VERSION
 
-use Moose;
 use MooseX::Types::URI qw/ Uri /;
 use URN::OASIS::SAML2 qw(:urn);
 

--- a/lib/Net/SAML2/Protocol/LogoutRequest.pm
+++ b/lib/Net/SAML2/Protocol/LogoutRequest.pm
@@ -1,7 +1,6 @@
 package Net::SAML2::Protocol::LogoutRequest;
-# VERSION
-
 use Moose;
+# VERSION
 use MooseX::Types::Common::String qw/ NonEmptySimpleStr /;
 use MooseX::Types::URI qw/ Uri /;
 use Net::SAML2::XML::Util qw/ no_comments /;

--- a/lib/Net/SAML2/Types.pm
+++ b/lib/Net/SAML2/Types.pm
@@ -1,7 +1,8 @@
 package Net::SAML2::Types;
-# VERSION
 use warnings;
 use strict;
+
+# VERSION
 
 # ABSTRACT: Custom Moose types for Net::SAML2
 


### PR DESCRIPTION
Add a perlcriticrc file which treats `use Moose` as `use strict; use warnings`.
Add trusted POD for BUILD methods of Moose. These do not need to be documented
as they are part of the Moose API:

https://metacpan.org/dist/Moose/view/lib/Moose/Manual/Construction.pod#BUILD

Signed-off-by: Wesley Schwengle <waterkip@cpan.org>