### PR TITLE
make Redirect::key optional

### DIFF
--- a/lib/Net/SAML2/Binding/Redirect.pm
+++ b/lib/Net/SAML2/Binding/Redirect.pm
@@ -50,7 +50,8 @@ Arguments:
 The SP's (Service Provider) also known as your application's signing key
 that your application uses to sign the AuthnRequest.  Some IdPs may not
 verify the signature.
-Required with B<param> being C<SAMLRequest>.
+
+If not provided, C<sign> will return a non-signed URL.
 
 =item B<cert>
 
@@ -120,7 +121,6 @@ sub BUILD {
 
     if ($self->param eq 'SAMLRequest') {
         croak("Need to have an URL specified") unless $self->has_url;
-        croak("Need to have a key specified") unless $self->has_key;
     }
     elsif ($self->param eq 'SAMLResponse') {
         croak("Need to have a cert specified") unless $self->has_cert;
@@ -170,6 +170,8 @@ sub sign {
     my $u = URI->new($self->url);
     $u->query_param($self->param, $req);
     $u->query_param('RelayState', $relaystate) if defined $relaystate;
+
+    return $u->as_string unless $self->has_key;
 
     my $key_string = read_text($self->key);
     my $rsa_priv = Crypt::OpenSSL::RSA->new_private_key($key_string);

--- a/lib/Net/SAML2/Binding/Redirect.pm
+++ b/lib/Net/SAML2/Binding/Redirect.pm
@@ -53,7 +53,7 @@ verify the signature.
 
 Usually required when B<param> is C<SAMLRequest>.
 
-If you don't want to sign the request, you can pass B<< insecure => 1
+If you don't want to sign the request, you can pass C<< insecure => 1
 >> and not provide a key; in this case, C<sign> will return a
 non-signed URL.
 

--- a/lib/Net/SAML2/Binding/Redirect.pm
+++ b/lib/Net/SAML2/Binding/Redirect.pm
@@ -51,7 +51,11 @@ The SP's (Service Provider) also known as your application's signing key
 that your application uses to sign the AuthnRequest.  Some IdPs may not
 verify the signature.
 
-If not provided, C<sign> will return a non-signed URL.
+Usually required when B<param> is C<SAMLRequest>.
+
+If you don't want to sign the request, you can pass B<< insecure => 1
+>> and not provide a key; in this case, C<sign> will return a
+non-signed URL.
 
 =item B<cert>
 
@@ -92,6 +96,8 @@ has 'cert' => (isa => 'ArrayRef[Str]', is => 'ro', required => 0, predicate => '
 has 'url'  => (isa => Uri, is => 'ro', required => 0, coerce => 1, predicate => 'has_url');
 has 'key'  => (isa => 'Str', is => 'ro', required => 0, predicate => 'has_key');
 
+has 'insecure'  => (isa => 'Bool', is => 'ro', default => 0 );
+
 has 'param' => (
     isa      => SAMLRequestType,
     is       => 'ro',
@@ -121,6 +127,7 @@ sub BUILD {
 
     if ($self->param eq 'SAMLRequest') {
         croak("Need to have an URL specified") unless $self->has_url;
+        croak("Need to have a key specified") unless $self->has_key || $self->insecure;
     }
     elsif ($self->param eq 'SAMLResponse') {
         croak("Need to have a cert specified") unless $self->has_cert;
@@ -171,7 +178,7 @@ sub sign {
     $u->query_param($self->param, $req);
     $u->query_param('RelayState', $relaystate) if defined $relaystate;
 
-    return $u->as_string unless $self->has_key;
+    return $u->as_string if $self->insecure;
 
     my $key_string = read_text($self->key);
     my $rsa_priv = Crypt::OpenSSL::RSA->new_private_key($key_string);

--- a/t/06-redirect-binding.t
+++ b/t/06-redirect-binding.t
@@ -85,4 +85,26 @@ throws_ok(
     "Need an URL for SAMLRequest"
 );
 
+throws_ok(
+    sub {
+        Net::SAML2::Binding::Redirect->new(
+            url   => 'https://foo.example.com',
+        );
+    },
+    qr/Need to have a key specified/,
+    "Need a key for SAMLRequest"
+);
+
+lives_ok(
+    sub {
+        Net::SAML2::Binding::Redirect->new(
+            url      => 'https://foo.example.com',
+            insecure => 1,
+        );
+    },
+    "We don't need a key for an insecure SAMLRequest"
+);
+
+
+
 done_testing;

--- a/t/06-redirect-binding.t
+++ b/t/06-redirect-binding.t
@@ -85,14 +85,4 @@ throws_ok(
     "Need an URL for SAMLRequest"
 );
 
-throws_ok(
-    sub {
-        Net::SAML2::Binding::Redirect->new(
-            url   => 'https://foo.example.com',
-        );
-    },
-    qr/Need to have a key specified/,
-    "Need a key for SAMLRequest"
-);
-
 done_testing;


### PR DESCRIPTION
since, as the documentation already says, some IdP don't check the request signature, we can make it optional