### PR TITLE
Set authors and contributors

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,20 @@
+
+# NET-SAML2 CONTRIBUTORS #
+
+This is the (likely incomplete) list of people who have helped
+make this distribution what it is, either via code contributions, 
+patches, bug reports, help with troubleshooting, etc. A huge
+'thank you' to all of them.
+
+    * Timothy Legge
+    * Wesley Schwengle
+    * Chris Andrews
+    * Alessandro Ranellucci
+    * Mike Wisener
+    * Peter Marschall
+    * Gianni Ceccarelli
+    * Jeff Fearn
+    * Ali Zia
+    * Oskari Okko Ojala
+
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This software is copyright (c) 2022 by Chris Andrews and Others, see the git log.
+This software is copyright (c) 2022 by Venda Ltd, see the CONTRIBUTORS file for others.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
@@ -12,7 +12,7 @@ b) the "Artistic License"
 
 --- The GNU General Public License, Version 1, February 1989 ---
 
-This software is Copyright (c) 2022 by Chris Andrews and Others, see the git log.
+This software is Copyright (c) 2022 by Venda Ltd, see the CONTRIBUTORS file for others.
 
 This is free software, licensed under:
 
@@ -272,7 +272,7 @@ That's all there is to it!
 
 --- The Artistic License 1.0 ---
 
-This software is Copyright (c) 2022 by Chris Andrews and Others, see the git log.
+This software is Copyright (c) 2022 by Venda Ltd, see the CONTRIBUTORS file for others.
 
 This is free software, licensed under:
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,7 +7,7 @@ use ExtUtils::MakeMaker;
 
 my %WriteMakefileArgs = (
   "ABSTRACT" => "SAML bindings and protocol implementation",
-  "AUTHOR" => "Chris Andrews  <chrisa\@cpan.org>",
+  "AUTHOR" => "Chris Andrews  <chrisa\@cpan.org>, Timothy Legge <timlegge\@gmail.com>",
   "CONFIGURE_REQUIRES" => {
     "ExtUtils::MakeMaker" => 0
   },
@@ -76,7 +76,7 @@ my %WriteMakefileArgs = (
     "URI::URL" => 0,
     "XML::LibXML::XPathContext" => 0
   },
-  "VERSION" => "0.62",
+  "VERSION" => "0.63",
   "test" => {
     "TESTS" => "t/*.t t/author/*.t"
   }

--- a/README
+++ b/README
@@ -2,7 +2,7 @@ NAME
     Net::SAML2 - SAML2 bindings and protocol implementation
 
 VERSION
-    version 0.62
+    version 0.63
 
 SYNOPSIS
       See TUTORIAL.md for implementation documentation and
@@ -87,40 +87,18 @@ DESCRIPTION
         required to existing SP applications if EncryptedAssertions are not
         in use.
 
-NAME
-    Net::SAML2 - SAML bindings and protocol implementation
-
 MAJOR CAVEATS
     SP-side protocol only
     Requires XML metadata from the IdP
 
-CONTRIBUTORS
-    Chris Andrews <chris@nodnol.org>
-    Oskari Okko Ojala <okko@frantic.com>
-    Peter Marschall <peter@adpm.de>
-    Mike Wisener <xmikew@cpan.org>
-    Jeff Fearn <jfearn@redhat.com>
-    Alessandro Ranellucci <aar@cpan.org>
-    Mike Wisener <mwisener@secureworks.com>, xmikew <github@32ths.com>
-    xmikew <github@32ths.com>
-    Timothy Legge <timlegge@gmail.com>
+AUTHORS
+    *   Chris Andrews <chrisa@cpan.org>
 
-COPYRIGHT
-    The following copyright notice applies to all the files provided in this
-    distribution, including binary files, unless explicitly noted otherwise.
-
-    Copyright 2010, 2011 Venda Ltd.
-
-LICENCE
-    This library is free software; you can redistribute it and/or modify it
-    under the same terms as Perl itself.
-
-AUTHOR
-    Chris Andrews <chrisa@cpan.org>
+    *   Timothy Legge <timlegge@gmail.com>
 
 COPYRIGHT AND LICENSE
-    This software is copyright (c) 2022 by Chris Andrews and Others, see the
-    git log.
+    This software is copyright (c) 2022 by Venda Ltd, see the CONTRIBUTORS
+    file for others.
 
     This is free software; you can redistribute it and/or modify it under
     the same terms as the Perl 5 programming language system itself.

--- a/dist.ini
+++ b/dist.ini
@@ -1,14 +1,16 @@
 name    = Net-SAML2
 abstract = SAML bindings and protocol implementation
-author  = Chris Andrews  <chrisa@cpan.org>
-copyright_holder = Chris Andrews and Others, see the git log
-main_module = lib/Net/SAML2.pm
-; [...]
+authors = Chris Andrews  <chrisa@cpan.org>
+authors = Timothy Legge <timlegge@gmail.com>
+copyright_holder = Venda Ltd, see the CONTRIBUTORS file for others
 license = Perl_5
+main_module = lib/Net/SAML2.pm
+
 [Meta::Maintainers]
 maintainer = Timothy Legge <timlegge@gmail.com>
 
 [Git::Contributors]
+order_by = commits
 include_authors = 1
 
 [@Filter]
@@ -22,6 +24,7 @@ remove = Readme
 exclude_filename = cpanfile
 exclude_filename = Makefile.PL
 exclude_filename = LICENSE
+exclude_filename = CONTRIBUTORS
 exclude_match = xt\/testapp\/.*
 exclude_filename = README
 
@@ -36,9 +39,10 @@ copy = cpanfile
 copy = Makefile.PL
 copy = README
 copy = LICENSE
+copy = CONTRIBUTORS
 
 [CopyFilesFromRelease]
-copy = cpanfile, Makefile.PL, README
+copy = cpanfile, Makefile.PL, README, LICENSE, CONTRIBUTORS
 
 [AutoPrereqs]
 skip = Saml2Test
@@ -76,6 +80,9 @@ web = https://github.com/perl-net-saml2/perl-Net-SAML2/issues
 [NextRelease]
 format = %v -- %{EEE MMM dd HH:mm:ss VVV yyyy}d
 filename = Changes
+
+[ContributorsFile]
+filename = CONTRIBUTORS
 
 [Git::NextVersion]
 first_version = 0.001       ; this is the default

--- a/lib/Net/SAML2.pm
+++ b/lib/Net/SAML2.pm
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 package Net::SAML2;
-our $VERSION = "0.62";
+our $VERSION = "0.63";
 
 require 5.008_001;
 

--- a/lib/Net/SAML2.pm
+++ b/lib/Net/SAML2.pm
@@ -7,9 +7,25 @@ require 5.008_001;
 
 # ABSTRACT: SAML2 bindings and protocol implementation
 
-=head1 NAME
+# entities
+use Net::SAML2::IdP;
+use Net::SAML2::SP;
 
-Net::SAML2 - SAML bindings and protocol implementation
+# bindings
+use Net::SAML2::Binding::Redirect;
+use Net::SAML2::Binding::POST;
+use Net::SAML2::Binding::SOAP;
+
+# protocol
+use Net::SAML2::Protocol::AuthnRequest;
+use Net::SAML2::Protocol::LogoutRequest;
+use Net::SAML2::Protocol::LogoutResponse;;
+use Net::SAML2::Protocol::Assertion;
+use Net::SAML2::Protocol::ArtifactResolve;
+
+1;
+
+__END__
 
 =head1 SYNOPSIS
 
@@ -116,66 +132,3 @@ SP applications if EncryptedAssertions are not in use.
 =item Requires XML metadata from the IdP
 
 =back
-
-=cut
-
-# entities
-use Net::SAML2::IdP;
-use Net::SAML2::SP;
-
-# bindings
-use Net::SAML2::Binding::Redirect;
-use Net::SAML2::Binding::POST;
-use Net::SAML2::Binding::SOAP;
-
-# protocol
-use Net::SAML2::Protocol::AuthnRequest;
-use Net::SAML2::Protocol::LogoutRequest;
-use Net::SAML2::Protocol::LogoutResponse;;
-use Net::SAML2::Protocol::Assertion;
-use Net::SAML2::Protocol::ArtifactResolve;
-
-=pod
-
-=head1 CONTRIBUTORS
-
-=over
-
-=item Alessandro Ranellucci <aar@cpan.org>
-
-=item Ali Zia <ziali088@gmail.com>
-
-=item Chris Andrews <chris@nodnol.org>
-
-=item Gianni Ceccarelli <gianni.ceccarelli@broadbean.com>
-
-=item Jeff Fearn <jfearn@redhat.com>
-
-=item Mike Wisener <xmikew@cpan.org>, <mwisener@secureworks.com>, xmikew <github@32ths.com>
-
-=item Oskari Okko Ojala <okko@frantic.com>
-
-=item Peter Marschall <peter@adpm.de>
-
-=item Timothy Legge <timlegge@gmail.com>
-
-=item Wesley Schwengle <waterkip@cpan.org>
-
-=back
-
-=head1 COPYRIGHT
-
-The following copyright notice applies to all the files provided in
-this distribution, including binary files, unless explicitly noted
-otherwise.
-
-Copyright 2010, 2011 Venda Ltd.
-
-=head1 LICENCE
-
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself.
-
-=cut
-
-1;


### PR DESCRIPTION
Use ContributesFile to tell who is a contributor and update the authors of this module to the previous and current maintainer(s).

Signed-off-by: Wesley Schwengle <waterkip@cpan.org>