### PR TITLE
Set sane default values for testing testapp

### DIFF
--- a/xt/testapp/config.yml
+++ b/xt/testapp/config.yml
@@ -17,6 +17,6 @@ org_display_name: "Saml2Test app for Net::SAML2"
 org_contact: "saml2test@example.com"
 error_url: "/error"
 force_authn: 1
-is_passive: 1
+is_passive: 0
 sign_metadata: 1
 authnreq_signed: 1

--- a/xt/testapp/environments/development.yml
+++ b/xt/testapp/environments/development.yml
@@ -1,4 +1,4 @@
 log: "debug"
-warnings: 1
+warnings: 0
 show_errors: 1
 auto_reload: 0


### PR DESCRIPTION
Many IDPs error with IsPassive set

Dancer treats any warnings as fatal which causes IdPs with multiple certs to die