### PR TITLE
Install Sub::Name without running tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,9 @@ jobs:
           echo '35c896266e4257793387ba22d5d76078  pari-2.3.4.tar.gz' | md5sum -c - ;
           tar zxf pari-2.3.4.tar.gz;
           cd - ;
-          cpm install -g --test --show-build-log-on-failure Sub::Name;
+          # Sub::Name has test that fail every so many times on t/lexical.t
+          # we ignore these test failures for now...
+          cpm install -g --show-build-log-on-failure Sub::Name;
           cpm install -g --test --show-build-log-on-failure --cpanfile cpanfile;
       - name: Build Module
         run: |


### PR DESCRIPTION
t/lexical.t fails every now and than, for more information: https://rt.cpan.org/Public/Bug/Display.html?id=125159

Signed-off-by: Wesley Schwengle <waterkip@cpan.org>