### PR TITLE
Get the substatus of a failed assertion

### DIFF
--- a/t/03-assertions.t
+++ b/t/03-assertions.t
@@ -159,4 +159,24 @@ lives_ok(
     "Correct parsing of plain ADFS"
 );
 
+lives_ok(
+    sub {
+       my  $xml = path('t/data/failed-assertion.xml')->slurp;
+       $assertion = Net::SAML2::Protocol::Assertion->new_from_xml(xml => $xml);
+    },
+    "Correct parsing of failed assertion"
+);
+
+ok(!$assertion->success, ".. not a success");
+is(
+    $assertion->response_status,
+    "main status",
+    "... and the status also indicates not a success"
+);
+is(
+    $assertion->response_substatus,
+    "sub status",
+    "... and the sub status yay"
+);
+
 done_testing;

--- a/t/data/failed-assertion.xml
+++ b/t/data/failed-assertion.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_f0b0652f-1382-43af-a70e-97254820f180" Version="2.0" IssueInstant="2018-07-25T08:02:24.342Z" Destination="https://testsuite.zaaksysteem.nl/auth/saml/consumer-post" Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified" InResponseTo="_c217d2c8502884bf418552907827f430d745fa6c">
+  <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">http://adfs.dev.mintlab.nl/adfs/services/trust</Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="main status">
+      <samlp:StatusCode Value="sub status"/>
+    </samlp:StatusCode>
+    <samlp:StatusMessage>Authentication Failed</samlp:StatusMessage>
+    <samlp:StatusDetail>
+      <Cause>org.sourceid.websso.profiles.idp.FailedAuthnSsoException</Cause>
+    </samlp:StatusDetail>
+  </samlp:Status>
+  <Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_0024c3a6-3b4e-4920-8c59-0602ae4a3c5d" IssueInstant="2018-07-25T08:02:24.341Z" Version="2.0">
+    <Issuer>http://adfs.dev.mintlab.nl/adfs/services/trust</Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:SignedInfo>
+        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+        <ds:Reference URI="#_0024c3a6-3b4e-4920-8c59-0602ae4a3c5d">
+          <ds:Transforms>
+            <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          </ds:Transforms>
+          <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+          <ds:DigestValue>/UGIkccgX9xPwusXApqxm7KDyLpgx7W/tp6gANTvNsw=</ds:DigestValue>
+        </ds:Reference>
+      </ds:SignedInfo>
+      <ds:SignatureValue/>
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate/>
+        </ds:X509Data>
+      </KeyInfo>
+    </ds:Signature>
+    <Subject>
+      <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <SubjectConfirmationData InResponseTo="_c217d2c8502884bf418552907827f430d745fa6c" NotOnOrAfter="2018-07-25T08:07:24.342Z" Recipient="https://testsuite.zaaksysteem.nl/auth/saml/consumer-post"/>
+      </SubjectConfirmation>
+    </Subject>
+    <Conditions NotBefore="2018-07-25T08:02:24.338Z" NotOnOrAfter="2018-07-25T09:02:24.338Z">
+      <AudienceRestriction>
+        <Audience>TestUPN</Audience>
+      </AudienceRestriction>
+    </Conditions>
+    <AuthnStatement AuthnInstant="2018-07-25T07:54:35.599Z">
+      <AuthnContext>
+        <AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</AuthnContextClassRef>
+      </AuthnContext>
+    </AuthnStatement>
+  </Assertion>
+</samlp:Response>


### PR DESCRIPTION
This allows consumers to expose the reason of the failure.

Signed-off-by: Wesley Schwengle <waterkip@cpan.org>