### PR TITLE
testapp: miscellaneous changes 

### DIFF
--- a/xt/testapp/config.yml
+++ b/xt/testapp/config.yml
@@ -22,3 +22,4 @@ is_passive: 0
 sign_metadata: 1
 authnreq_signed: 1
 ssl_verify_hostname: 0
+acs_url_in_request: 1

--- a/xt/testapp/lib/Saml2Test.pm
+++ b/xt/testapp/lib/Saml2Test.pm
@@ -118,6 +118,8 @@ sub get_login_post {
     my $sp  = _sp();
 
     my %params = (
+        defined (config->{acs_url_in_request}) and (config->{acs_url_in_request} eq 1) ?
+            (assertion_url => config->{url} . config->{acs_url_post}) : (),
         defined (config->{force_authn}) ? (force_authn => config->{force_authn}) : (),
         defined (config->{is_passive}) ? (is_passive  => config->{is_passive}) : (),
     );
@@ -179,6 +181,8 @@ get '/login' => sub {
     my $sp = _sp();
 
     my %params = (
+        defined (config->{acs_url_in_request}) and (config->{acs_url_in_request} eq 1) ?
+            (assertion_url => config->{url} . config->{acs_url_post}) : (),
         defined (config->{force_authn}) ? (force_authn => config->{force_authn}) : (),
         defined (config->{is_passive}) ? (is_passive  => config->{is_passive}) : (),
     );

--- a/xt/testapp/lib/Saml2Test.pm
+++ b/xt/testapp/lib/Saml2Test.pm
@@ -608,20 +608,14 @@ sub _sp {
         {
             Binding => BINDING_HTTP_REDIRECT,
             Location => config->{url} . config->{slo_url_redirect},
-            isDefault => 'true',
-            index => 1,
         },
         {
             Binding => BINDING_HTTP_POST,
             Location => config->{url} . config->{slo_url_post},
-            isDefault => 'false',
-            index => 2,
         },
         {
             Binding => BINDING_HTTP_ARTIFACT,
             Location => config->{url} . config->{slo_url_soap},
-            isDefault => 'false',
-            index => 3,
         }],
         assertion_consumer_service => [
         {


### PR DESCRIPTION
Some IdPs require ate ACS URL to be specified in the AuthnRequest in some situations.
Indexes not supported in metadata for SingleLogout URLs