### PR TITLE
Fix NAME segment of POD for modules.

### DIFF
--- a/lib/Net/SAML2/Binding/POST.pm
+++ b/lib/Net/SAML2/Binding/POST.pm
@@ -6,7 +6,7 @@ package Net::SAML2::Binding::POST;
 use Moose;
 use Carp qw(croak);
 
-# ABSTRACT: Net::SAML2::Binding::POST - HTTP POST binding for SAML
+# ABSTRACT: HTTP POST binding for SAML
 
 =head1 NAME
 

--- a/lib/Net/SAML2/Binding/Redirect.pm
+++ b/lib/Net/SAML2/Binding/Redirect.pm
@@ -17,7 +17,7 @@ use URI::Escape qw(uri_unescape);
 use URI::QueryParam;
 use URI;
 
-# ABSTRACT: Net::SAML2::Binding::Redirect - HTTP Redirect binding for SAML
+# ABSTRACT: HTTP Redirect binding for SAML
 
 =head1 SYNOPSIS
 

--- a/lib/Net/SAML2/Binding/SOAP.pm
+++ b/lib/Net/SAML2/Binding/SOAP.pm
@@ -10,7 +10,7 @@ use Try::Tiny;
 
 with 'Net::SAML2::Role::VerifyXML';
 
-# ABSTRACT: Net::SAML2::Binding::SOAP - SOAP binding for SAML
+# ABSTRACT: SOAP binding for SAML
 
 =head1 SYNOPSIS
 

--- a/lib/Net/SAML2/IdP.pm
+++ b/lib/Net/SAML2/IdP.pm
@@ -5,7 +5,7 @@ use Moose;
 
 use MooseX::Types::URI qw/ Uri /;
 
-# ABSTRACT: Net::SAML2::IdP - SAML Identity Provider object
+# ABSTRACT: SAML Identity Provider object
 
 =head1 NAME
 

--- a/lib/Net/SAML2/Protocol/Artifact.pm
+++ b/lib/Net/SAML2/Protocol/Artifact.pm
@@ -11,7 +11,7 @@ use XML::LibXML;
 
 with 'Net::SAML2::Role::ProtocolMessage';
 
-# ABSTRACT: Net::SAML2::Protocol::Artifact - SAML2 artifact object
+# ABSTRACT: SAML2 artifact object
 
 =head1 NAME
 

--- a/lib/Net/SAML2/Protocol/ArtifactResolve.pm
+++ b/lib/Net/SAML2/Protocol/ArtifactResolve.pm
@@ -7,7 +7,7 @@ use URN::OASIS::SAML2 qw(:urn);
 
 with 'Net::SAML2::Role::ProtocolMessage';
 
-# ABSTRACT: Net::SAML2::Protocol::ArtifactResolve - ArtifactResolve protocol class
+# ABSTRACT: ArtifactResolve protocol class
 
 =head1 NAME
 

--- a/lib/Net/SAML2/Protocol/Assertion.pm
+++ b/lib/Net/SAML2/Protocol/Assertion.pm
@@ -18,7 +18,7 @@ use Carp qw(croak);
 
 with 'Net::SAML2::Role::ProtocolMessage';
 
-# ABSTRACT: Net::SAML2::Protocol::Assertion - SAML2 assertion object
+# ABSTRACT: SAML2 assertion object
 
 =head1 NAME
 

--- a/lib/Net/SAML2/SP.pm
+++ b/lib/Net/SAML2/SP.pm
@@ -20,7 +20,7 @@ use Net::SAML2::Util ();
 use URN::OASIS::SAML2 qw(:bindings :urn);
 use XML::Generator;
 
-# ABSTRACT: Net::SAML2::SP - SAML Service Provider object
+# ABSTRACT: SAML Service Provider object
 
 =head1 SYNOPSIS
 

--- a/lib/Net/SAML2/XML/Util.pm
+++ b/lib/Net/SAML2/XML/Util.pm
@@ -16,7 +16,7 @@ use base qw/Exporter/;
 # Export list - to allow fine tuning of export table
 @EXPORT_OK = qw( no_comments );
 
-# ABSTRACT: Net::SAML2::XML::Util - XML Util class
+# ABSTRACT: XML Util class
 
 =head1 NAME
 


### PR DESCRIPTION
Before, the command `perldoc Net::SAML2::Protocol::Assertion` would produce the output "Net::SAML2::Protocol::Assertion - Net::SAML2::Protocol::Assertion - SAML2 assertion object". The output has been simplified to "Net::SAML2::Protocol::Assertion - SAML2 assertion object".