### PR TITLE
Always return a default assertion service

### DIFF
--- a/lib/Net/SAML2/SP.pm
+++ b/lib/Net/SAML2/SP.pm
@@ -264,10 +264,6 @@ around BUILDARGS => sub {
         }
     }
 
-    foreach (@{$args{assertion_consumer_service}}) {
-        $_->{isDefault} = 'false' if !exists $_->{isDefault};
-    }
-
     return $self->$orig(%args);
 };
 
@@ -703,8 +699,14 @@ Return the assertion service which is the default
 
 sub get_default_assertion_service {
     my $self = shift;
-    return first { $_->{isDefault} eq 1 || $_->{isDefault} eq 'true' }
-        @{ $self->assertion_consumer_service };
+    my $default = first { $_->{isDefault} eq 1 || $_->{isDefault} eq 'true' }
+        grep { defined $_->{isDefault} } @{ $self->assertion_consumer_service };
+    return $default if $default;
+
+    $default = first { ! defined $_->{isDefault} } @{ $self->assertion_consumer_service };
+    return $default if $default;
+
+    return $self->assertion_consumer_service->[0];
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf 2.2.3 Complex Type IndexedEndpointType

isDefault [Optional]

An optional boolean attribute used to designate the default endpoint among an indexed set. If omitted, the value is assumed to be false.

In any such sequence of like endpoints based on this type, the default endpoint is the first such endpoint with the isDefault attribute set to true. If no such endpoints exist, the default endpoint is the first such endpoint without the isDefault attribute set to false. If no such endpoints exist, the default endpoint is the first element in the sequence