### PR TITLE
Split Github Actions workflow

### DIFF
--- a/.github/workflows/perl-eol.yml
+++ b/.github/workflows/perl-eol.yml
@@ -1,0 +1,26 @@
+---
+name: perl-eol
+
+on:
+  workflow_run:
+    workflows: ["perl-legacy"]
+    types:
+      - completed
+    branches:
+      - "**"
+
+jobs:
+  perl:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/shared-workflow.yml
+    with:
+      perl-version: ${{ matrix.perl-version }}
+    strategy:
+      matrix:
+        perl-version:
+          - '5.14-buster'
+          - '5.16-buster'
+          - '5.18-buster'
+          - '5.20-buster'
+          - '5.22-buster'
+          - '5.24-buster'

--- a/.github/workflows/perl-legacy.yml
+++ b/.github/workflows/perl-legacy.yml
@@ -1,0 +1,25 @@
+---
+name: perl-legacy
+
+on:
+  workflow_run:
+    workflows: ["perl"]
+    branches:
+      - '**' # All branches by default only the default branch is used
+
+    types:
+      - completed
+
+jobs:
+  perl:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/shared-workflow.yml
+    with:
+      perl-version: ${{ matrix.perl-version }}
+    strategy:
+      matrix:
+        perl-version:
+          - '5.26'
+          - '5.28'
+          - '5.30'
+          - '5.32'

--- a/.github/workflows/perl.yml
+++ b/.github/workflows/perl.yml
@@ -1,0 +1,22 @@
+---
+name: perl
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  testing:
+    strategy:
+      matrix:
+        perl-version:
+          - '5.34'
+          - '5.36'
+        include:
+          - perl-version: '5.38'
+            release-test: true
+            coverage: true
+    uses: ./.github/workflows/shared-workflow.yml
+    with:
+      perl-version: ${{ matrix.perl-version }}
+      coverage: ${{ matrix.coverage }}

--- a/.github/workflows/shared-workflow.yml
+++ b/.github/workflows/shared-workflow.yml
@@ -1,35 +1,22 @@
 ---
-name: linux
+name: shared-workflow
 
 on:
-  - push
-  - pull_request
+  workflow_call:
+    inputs:
+      perl-version:
+        required: true
+        type: string
+      coverage:
+        required: false
+        type: string
+
 
 jobs:
-  perl:
+  testing:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        perl-version:
-          - '5.12-buster'
-          - '5.14-buster'
-          - '5.16-buster'
-          - '5.18-buster'
-          - '5.20-buster'
-          - '5.22-buster'
-          - '5.24-buster'
-          - '5.26'
-          - '5.28'
-          - '5.30'
-          - '5.32'
-          - '5.34'
-          - '5.36'
-        include:
-          - perl-version: '5.38'
-            release-test: true
-            coverage: true
     container:
-      image: perl:${{ matrix.perl-version }}
+      image: perl:${{ inputs.perl-version }}
     steps:
       - uses: actions/checkout@v1
       - name: Install Net::SAML2 Depends
@@ -46,11 +33,11 @@ jobs:
           perl Makefile.PL;
           make
       - name: Run tests
-        if: ${{ !matrix.coverage  }}
+        if: ${{ !inputs.coverage  }}
         run: |
           prove -lr -l -b -I inc t
       - name: Run tests including coverage
-        if: ${{ matrix.coverage  }}
+        if: ${{ inputs.coverage  }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PERL_SERVICE_NAME: github-actions

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use 5.012;
+use 5.014;
 
 use ExtUtils::MakeMaker;
 
@@ -13,7 +13,7 @@ my %WriteMakefileArgs = (
   },
   "DISTNAME" => "Net-SAML2",
   "LICENSE" => "perl",
-  "MIN_PERL_VERSION" => "5.012",
+  "MIN_PERL_VERSION" => "5.014",
   "NAME" => "Net::SAML2",
   "PREREQ_PM" => {
     "Carp" => 0,

--- a/cpanfile
+++ b/cpanfile
@@ -39,7 +39,7 @@ requires "XML::LibXML" => "0";
 requires "XML::LibXML::XPathContext" => "0";
 requires "XML::Sig" => "0.64";
 requires "namespace::autoclean" => "0";
-requires "perl" => "5.012";
+requires "perl" => "5.014";
 
 on 'test' => sub {
   requires "Import::Into" => "0";

--- a/dist.ini
+++ b/dist.ini
@@ -54,6 +54,7 @@ skip = overload
 skip = base
 
 [Prereqs / RuntimeRequires]
+perl = 5.014
 XML::Enc = 0.13
 XML::Sig = 0.64
 ; Here because it isn't provided by Crypt::OpenSSL::RSA


### PR DESCRIPTION
We supported perl 5.12 - perl 5.38, which are about 14 versions of Perl. The CI ran tests for all of them and if one of them failed, they all failed. This is a weebit anoying. Now we split the CI in three sections:

1. We test the last 3 versions of perl
2. We test every version which does not require Debian buster
3. We test every version which requires Debian buster

This allows us to first test the latest versions of Perl and will later fail if older versions fail.

Additionally, bump Perl version to 5.14 as IO::Socket::IP bumped its version requirement as well[^1][^2].

[^1]: https://rt.cpan.org/Public/Bug/Display.html?id=149138
[^2]: https://metacpan.org/dist/IO-Socket-IP/changes