### PR TITLE
Rename id to issuer for Net::SAML2::SP

### DIFF
--- a/lib/Net/SAML2/Protocol/AuthnRequest.pm
+++ b/lib/Net/SAML2/Protocol/AuthnRequest.pm
@@ -7,6 +7,7 @@ use MooseX::Types::Common::String qw/ NonEmptySimpleStr /;
 use XML::Generator;
 use List::Util        qw(any);
 use URN::OASIS::SAML2 qw(:urn BINDING_HTTP_POST);
+use Net::SAML2::Util ();
 
 with 'Net::SAML2::Role::ProtocolMessage';
 
@@ -179,9 +180,10 @@ around BUILDARGS => sub {
 
     my %params = @_;
     if ($params{nameid_format} && !defined $params{nameidpolicy_format}) {
-        warn "You are using nameid_format, this field has changed to "
-          . "nameidpolicy_format. This field will be used for other purposes "
-          . "in an upcoming release. Please change your code ASAP.";
+        Net::SAML2::Util::deprecation_warning "You are using nameid_format, "
+          . "this field has changed to nameidpolicy_format. This field will "
+          . "be used for other purposes in an upcoming release. Please change "
+          . "your code ASAP.";
         $params{nameidpolicy_format} = $params{nameid_format};
     }
 

--- a/lib/Net/SAML2/Util.pm
+++ b/lib/Net/SAML2/Util.pm
@@ -11,10 +11,15 @@ use Exporter qw(import);
 
 our @EXPORT_OK = qw(
     generate_id
+    deprecation_warning
 );
 
 sub generate_id {
     return 'NETSAML2_' . unpack 'H*', random_pseudo_bytes(32);
+}
+
+sub deprecation_warning {
+    warn "NET::SAML2 deprecation warning: " . shift . "\n";
 }
 
 

--- a/t/lib/Test/Net/SAML2/Util.pm
+++ b/t/lib/Test/Net/SAML2/Util.pm
@@ -41,7 +41,7 @@ our %EXPORT_TAGS = (
 
 sub net_saml2_sp {
     return Net::SAML2::SP->new(
-        id     => 'Some entity ID',
+        issuer => 'Some entity ID',
         cert   => 't/sign-nopw-cert.pem',
         key    => 't/sign-nopw-cert.pem',
         cacert => 't/cacert.pem',


### PR DESCRIPTION
We've had generate_sp_desciptor_id to override the ID, but this could
very well become a parameter for the constructor. The current ID
attribute was actually used as the issuer. Rename ID to issuer and and
reintroduce ID. We add some deprecation warnings to users so they are
aware of the change.