### PR TITLE
Fix signature location bug

### DIFF
--- a/t/02-create-sp.t
+++ b/t/02-create-sp.t
@@ -70,7 +70,10 @@ use URN::OASIS::SAML2 qw(:bindings :urn);
     }
 
 
-    get_single_node_ok($xpath, '//ds:Signature');
+    my $root_node = get_single_node_ok($xpath, '/md:EntityDescriptor');
+    my $signature_node = $root_node->firstChild;
+    is($signature_node->nodeName(),
+        'dsig:Signature', "First node is the signature");
 
     is(
         'e73560b0e23602121aedc55bcb1ca637',


### PR DESCRIPTION
In the XSD of SAML metadata the signature should be present directly after the md:EntityDescriptor tag as a child node. We placed it at the bottom of the field violating the XSD of SAML metadata.

We should potentially fix it in XML::Sig but that is for another day.