### PR TITLE
Add in_response_to to Role::ProtocolMessage

### DIFF
--- a/lib/Net/SAML2/Binding/SOAP.pm
+++ b/lib/Net/SAML2/Binding/SOAP.pm
@@ -12,6 +12,7 @@ use XML::LibXML::XPathContext;
 
 use Net::SAML2::XML::Sig;
 use Net::SAML2::XML::Util qw/ no_comments /;
+use Net::SAML2::Util qw/ deprecation_warning /;
 
 with 'Net::SAML2::Role::VerifyXML';
 
@@ -19,14 +20,14 @@ with 'Net::SAML2::Role::VerifyXML';
 
 =head1 SYNOPSIS
 
-  my $soap = Net::SAML2::Binding::SOAP->new(
-    url => $idp_url,
-    key => $key,
-    cert => $cert,
-    idp_cert => $idp_cert,
-  );
+    my $soap = Net::SAML2::Binding::SOAP->new(
+        url      => $idp_url,
+        key      => $key,
+        cert     => $cert,
+        idp_cert => $idp_cert,
+    );
 
-  my $response = $soap->request($req);
+    my $response = $soap->request($req);
 
 Note that LWP::UserAgent maybe used which means that environment variables
 may affect the use of https see:
@@ -129,6 +130,8 @@ has verify => (
 # expected to be an arrayref to the certificates.  To avoid breaking existing
 # applications this changes the the cert to an arrayref if it is not
 # already an array ref.
+#
+# Please remove the build args logic after 6 months from april 18th 2024
 
 around BUILDARGS => sub {
     my $orig = shift;
@@ -136,7 +139,8 @@ around BUILDARGS => sub {
 
     my %params = @_;
     if ($params{idp_cert} && ref($params{idp_cert}) ne 'ARRAY') {
-            $params{idp_cert} = [$params{idp_cert}];
+        $params{idp_cert} = [$params{idp_cert}];
+        deprecation_warning("Please use an array ref for idp_cert");
     }
 
     return $self->$orig(%params);

--- a/lib/Net/SAML2/Protocol/Artifact.pm
+++ b/lib/Net/SAML2/Protocol/Artifact.pm
@@ -1,5 +1,3 @@
-use strict;
-use warnings;
 package Net::SAML2::Protocol::Artifact;
 # VERSION
 
@@ -39,7 +37,7 @@ Net::SAML2::Protocol::Artifact - SAML2 artifact object
 =cut
 
 has 'issue_instant'   => (isa => DateTime,  is => 'ro', required => 1);
-has 'in_response_to'  => (isa => 'Str',     is => 'ro', required => 1);
+has '+in_response_to'  => (required => 1);
 has 'issuer'          => (isa => 'Str',     is => 'ro', required => 1);
 has 'status'          => (isa => 'Str',     is => 'ro', required => 1);
 has 'logoutresponse_object'  => (
@@ -100,12 +98,11 @@ sub new_from_xml {
     }
 
     my $issue_instant;
-
     if (my $value = $xpath->findvalue('/samlp:ArtifactResponse/@IssueInstant')) {
         $issue_instant = DateTime::Format::XSD->parse_datetime($value);
     }
 
-    my $self = $class->new(
+    return $class->new(
         id             => $xpath->findvalue('/samlp:ArtifactResponse/@ID'),
         in_response_to => $xpath->findvalue('/samlp:ArtifactResponse/@InResponseTo'),
         issue_instant  => $issue_instant,
@@ -114,8 +111,6 @@ sub new_from_xml {
         $response       ? (response        => $response)        : (),
         $logoutresponse ? (logout_response => $logoutresponse)  : (),
     );
-
-    return $self;
 }
 
 =head2 response
@@ -138,18 +133,6 @@ Returns the logoutresponse
 sub logout_response {
     my $self = shift;
     return $self->logoutresponse_object->toString;
-}
-
-=head2 success( )
-
-Returns true if the Response's status is Success.
-
-=cut
-
-sub success {
-    my ($self) = @_;
-    return 1 if $self->status eq $self->status_uri('success');
-    return 0;
 }
 
 =head2 get_response ( )

--- a/lib/Net/SAML2/Protocol/LogoutRequest.pm
+++ b/lib/Net/SAML2/Protocol/LogoutRequest.pm
@@ -16,12 +16,12 @@ with 'Net::SAML2::Role::ProtocolMessage';
 
 =head1 SYNOPSIS
 
-  my $logout_req = Net::SAML2::Protocol::LogoutRequest->new(
-    issuer      => $issuer,
-    destination => $destination,
-    nameid      => $nameid,
-    session     => $session,
-  );
+    my $logout_req = Net::SAML2::Protocol::LogoutRequest->new(
+        issuer      => $issuer,
+        destination => $destination,
+        nameid      => $nameid,
+        session     => $session,
+    );
 
 =head1 METHODS
 

--- a/lib/Net/SAML2/Role/ProtocolMessage.pm
+++ b/lib/Net/SAML2/Role/ProtocolMessage.pm
@@ -1,5 +1,3 @@
-use strict;
-use warnings;
 package Net::SAML2::Role::ProtocolMessage;
 # VERSION
 
@@ -7,12 +5,15 @@ use Moose::Role;
 
 # ABSTRACT: Common behaviour for Protocol messages
 
+use feature qw(state);
+
 use namespace::autoclean;
 
 use DateTime;
 use MooseX::Types::URI qw/ Uri /;
 use Net::SAML2::Util qw(generate_id);
 use Net::SAML2::Types qw(XsdID);
+use URN::OASIS::SAML2 qw(:status);
 
 =head1 NAME
 
@@ -66,6 +67,12 @@ has destination => (
     predicate => 'has_destination',
 );
 
+has in_response_to => (
+    isa       => XsdID,
+    is        => 'ro',
+    predicate => 'has_in_response_to',
+);
+
 sub _build_issue_instant {
     return DateTime->now(time_zone => 'UTC')->strftime('%FT%TZ');
 }
@@ -112,25 +119,34 @@ Legal short names for B<$status> are:
 
 =item C<responder>
 
+=item C<partial>
+
 =back
 
 =cut
 
+
 sub status_uri {
     my ($self, $status) = @_;
 
-    my $statuses = {
-        success   => 'urn:oasis:names:tc:SAML:2.0:status:Success',
-        requester => 'urn:oasis:names:tc:SAML:2.0:status:Requester',
-        responder => 'urn:oasis:names:tc:SAML:2.0:status:Responder',
+    state $statuses = {
+        success   => STATUS_SUCCESS(),
+        requester => STATUS_REQUESTER(),
+        responder => STATUS_RESPONDER(),
         partial   => 'urn:oasis:names:tc:SAML:2.0:status:PartialLogout',
     };
 
-    if (exists $statuses->{$status}) {
-        return $statuses->{$status};
-    }
-
+    return $statuses->{$status} if exists $statuses->{$status};
     return;
+}
+
+sub success {
+    my $self = shift;
+
+    return $self->status eq STATUS_SUCCESS() if $self->can('status');
+    croak(
+        "You haven't implemented the status method, unable to determine success"
+    );
 }
 
 1;

--- a/t/21-artifact-response.t
+++ b/t/21-artifact-response.t
@@ -127,7 +127,13 @@ isa_ok($logout, "Net::SAML2::Protocol::LogoutResponse");
 
 ok($logout->success(), "Logout Response has a Success");
 
-is($logout->response_to, 'NETSAML2_0b499739aa1d76eb80093a068053b8fee62cade60f7dc27826d0f13b19cad16a', "Logout Response InResponseTo - ok");
+is($logout->in_response_to, 'NETSAML2_0b499739aa1d76eb80093a068053b8fee62cade60f7dc27826d0f13b19cad16a', "Logout Response InResponseTo - ok");
+
+{
+  # TODO: Remove once response_to has been eradicated
+  local $SIG{__WARN__} = sub { }; # Suppress the warning in the testsuite
+  is($logout->response_to, $logout->in_response_to, ".. and old method still works");
+}
 
 is($logout->id, 'ID_bfc25851-4da2-4420-8240-9103b77b12dc', "Logout Response Id - ok");
 
@@ -139,6 +145,6 @@ isa_ok($logout, "Net::SAML2::Protocol::LogoutResponse", "from get_response");
 
 ok($logout->success(), "Logout Response has a Success");
 
-is($logout->response_to, 'NETSAML2_0b499739aa1d76eb80093a068053b8fee62cade60f7dc27826d0f13b19cad16a', "Logout Response InResponseTo - ok");
+is($logout->in_response_to, 'NETSAML2_0b499739aa1d76eb80093a068053b8fee62cade60f7dc27826d0f13b19cad16a', "Logout Response InResponseTo - ok");
 
 done_testing;


### PR DESCRIPTION
This attribute is needed in more than one type, so let's implement it.
Consumers may need to add the required bit.

In addition also add the success() method (although I think we need to
call it is_success).

Signed-off-by: Wesley Schwengle <waterkip@cpan.org>