### PR TITLE
Correctly test NameID attributes

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -59,7 +59,7 @@ XML::Enc = 0.13
 XML::Sig = 0.64
 ; Here because it isn't provided by Crypt::OpenSSL::RSA
 Crypt::OpenSSL::Bignum = 0
-URN::OASIS::SAML2 = 0.003
+URN::OASIS::SAML2 = 0.004
 XML::Generator = 1.13
 
 [Prereqs / TestRequires]

--- a/lib/Net/SAML2/Protocol/LogoutRequest.pm
+++ b/lib/Net/SAML2/Protocol/LogoutRequest.pm
@@ -7,7 +7,7 @@ use MooseX::Types::Common::String qw/ NonEmptySimpleStr /;
 use MooseX::Types::URI qw/ Uri /;
 use Net::SAML2::XML::Util qw/ no_comments /;
 use XML::Generator;
-use URN::OASIS::SAML2 qw(:urn);
+use URN::OASIS::SAML2 qw(:urn NAMEID_PERSISTENT);
 use XML::LibXML::XPathContext;
 
 with 'Net::SAML2::Role::ProtocolMessage';
@@ -123,7 +123,7 @@ around BUILDARGS => sub {
     my $self = shift;
     my %args = @_;
 
-    if ($args{nameid_format} && $args{nameid_format} eq 'urn:oasis:names:tc:SAML:2.0:nameidformat:persistent') {
+    if ($args{nameid_format} && $args{nameid_format} eq NAMEID_PERSISTENT()) {
         $args{include_name_qualifier} = 1;
     }
 

--- a/t/07-logout-request.t
+++ b/t/07-logout-request.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::Lib;
 use Test::Net::SAML2;
-use URN::OASIS::SAML2 qw(:urn);
+use URN::OASIS::SAML2 qw(:urn NAMEID_EMAIL);
 
 use Net::SAML2::Protocol::LogoutRequest;
 
@@ -49,6 +49,25 @@ is(
     undef,
     "We don't have SPProvidedID as an attribute in the nameid"
 );
+
+{
+    my $lor = Net::SAML2::Protocol::LogoutRequest->new(%args, nameid_format => NAMEID_EMAIL());
+    my $xpath = get_xpath(
+        $lor->as_xml,
+        samlp => URN_PROTOCOL,
+        saml  => URN_ASSERTION,
+    );
+    test_xml_attribute_ok($xpath, '/samlp:LogoutRequest/@ID', qr/^NETSAML2_/);
+    test_xml_attribute_ok($xpath, '/samlp:LogoutRequest/@IssueInstant', 'foo');
+    my $name_id = get_single_node_ok($xpath, '/samlp:LogoutRequest/saml:NameID');
+    is($name_id->getAttribute('Format'), NAMEID_EMAIL());
+
+    foreach (qw(NameQualifier SPNameQualifier SPProvidedID)) {
+        is($name_id->getAttribute($_),
+            undef, "We don't have $_ as an attribute in the nameid");
+    }
+
+}
 
 {
     my $lor = Net::SAML2::Protocol::LogoutRequest->new(%args,

--- a/t/07-logout-request.t
+++ b/t/07-logout-request.t
@@ -39,13 +39,16 @@ test_xml_attribute_ok($xpath, '/samlp:LogoutRequest/@IssueInstant', 'foo');
 my $name_id = get_single_node_ok($xpath, '/samlp:LogoutRequest/saml:NameID');
 is($name_id->getAttribute('Format'), $args{nameid_format});
 
-foreach (qw(NameQualifier SPNameQualifier SPProvidedID)) {
-    is(
-        $name_id->getAttribute($_),
-        undef,
-        "We don't have $_ as an attribute in the nameid"
-    );
+foreach (qw(NameQualifier SPNameQualifier)) {
+    isnt($name_id->getAttribute($_),
+        undef, "We don't have $_ as an attribute in the nameid");
 }
+
+is(
+    $name_id->getAttribute('SPProvidedID'),
+    undef,
+    "We don't have SPProvidedID as an attribute in the nameid"
+);
 
 {
     my $lor = Net::SAML2::Protocol::LogoutRequest->new(%args,


### PR DESCRIPTION
In 6c63ed1 we introduced some logic to make NameID attributes optional. On the checks is that urn:oasis:names:tc:SAML:2.0:nameidformat:persistent is special. There are two problems with this, one:
urn:oasis:names:tc:SAML:2.0:nameidformat:persistent should be urn:oasis:names:tc:SAML:2.0:nameid-format:persistent. And two: the test in t/07-logout-request.t should test that SPNameQualifier and NameQualifier are actually set and they are now not set (for the test that is). By fixing the typo, we need to change the tests to test the correct thing.

Closes: #213