### PR TITLE
Remove NAME sections in modules

### DIFF
--- a/lib/Net/SAML2/Binding/POST.pm
+++ b/lib/Net/SAML2/Binding/POST.pm
@@ -8,10 +8,6 @@ use Carp qw(croak);
 
 # ABSTRACT: HTTP POST binding for SAML
 
-=head1 NAME
-
-Net::SAML2::Binding::POST - HTTP POST binding for SAML2
-
 =head1 SYNOPSIS
 
   my $post = Net::SAML2::Binding::POST->new(

--- a/lib/Net/SAML2/IdP.pm
+++ b/lib/Net/SAML2/IdP.pm
@@ -3,12 +3,7 @@ use Moose;
 
 # VERSION
 
-
 # ABSTRACT: SAML Identity Provider object
-
-=head1 NAME
-
-Net::SAML2::IdP - SAML Identity Provider object
 
 =head1 SYNOPSIS
 

--- a/lib/Net/SAML2/Protocol/Artifact.pm
+++ b/lib/Net/SAML2/Protocol/Artifact.pm
@@ -13,10 +13,6 @@ with 'Net::SAML2::Role::ProtocolMessage';
 
 # ABSTRACT: SAML2 artifact object
 
-=head1 NAME
-
-Net::SAML2::Protocol::Artifact - SAML2 artifact object
-
 =head1 SYNOPSIS
 
   my $artifact = Net::SAML2::Protocol::Artifact->new_from_xml(

--- a/lib/Net/SAML2/Protocol/ArtifactResolve.pm
+++ b/lib/Net/SAML2/Protocol/ArtifactResolve.pm
@@ -9,10 +9,6 @@ with 'Net::SAML2::Role::ProtocolMessage';
 
 # ABSTRACT: ArtifactResolve protocol class
 
-=head1 NAME
-
-Net::SAML2::Protocol::ArtifactResolve - ArtifactResolve protocol class.
-
 =head1 SYNOPSIS
 
     my $resolver = Net::SAML2::Protocol::ArtifactResolve->new(

--- a/lib/Net/SAML2/Protocol/Assertion.pm
+++ b/lib/Net/SAML2/Protocol/Assertion.pm
@@ -20,10 +20,6 @@ with 'Net::SAML2::Role::ProtocolMessage';
 
 # ABSTRACT: SAML2 assertion object
 
-=head1 NAME
-
-Net::SAML2::Protocol::Assertion - SAML2 assertion object
-
 =head1 SYNOPSIS
 
   my $assertion = Net::SAML2::Protocol::Assertion->new_from_xml(

--- a/lib/Net/SAML2/Protocol/AuthnRequest.pm
+++ b/lib/Net/SAML2/Protocol/AuthnRequest.pm
@@ -13,10 +13,6 @@ with 'Net::SAML2::Role::ProtocolMessage';
 
 # ABSTRACT: SAML2 AuthnRequest object
 
-=head1 NAME
-
-Net::SAML2::Protocol::AuthnRequest - SAML2 AuthnRequest object
-
 =head1 SYNOPSIS
 
   my $authnreq = Net::SAML2::Protocol::AuthnRequest->new(

--- a/lib/Net/SAML2/Protocol/LogoutResponse.pm
+++ b/lib/Net/SAML2/Protocol/LogoutResponse.pm
@@ -12,10 +12,6 @@ with 'Net::SAML2::Role::ProtocolMessage';
 
 # ABSTRACT: SAML2 LogoutResponse Protocol object
 
-=head1 NAME
-
-Net::SAML2::Protocol::LogoutResponse - the SAML2 LogoutResponse object
-
 =head1 SYNOPSIS
 
   my $logout_req = Net::SAML2::Protocol::LogoutResponse->new(

--- a/lib/Net/SAML2/Role/ProtocolMessage.pm
+++ b/lib/Net/SAML2/Role/ProtocolMessage.pm
@@ -14,11 +14,6 @@ use MooseX::Types::URI qw/ Uri /;
 use Net::SAML2::Util qw(generate_id);
 use Net::SAML2::Types qw(XsdID);
 
-=head1 NAME
-
-Net::SAML2::Role::ProtocolMessage - the SAML2 ProtocolMessage Role object
-
-
 =head1 DESCRIPTION
 
 Provides default ID and timestamp arguments for Protocol classes.

--- a/lib/Net/SAML2/XML/Util.pm
+++ b/lib/Net/SAML2/XML/Util.pm
@@ -18,10 +18,6 @@ use base qw/Exporter/;
 
 # ABSTRACT: XML Util class
 
-=head1 NAME
-
-Net::SAML2::XML::Util - XML Util class.
-
 =head1 SYNOPSIS
 
   my $xml = no_comments($xml);


### PR DESCRIPTION
They are duplicated because we use ABSTRACT from dzil