### PR TITLE
Set key to be only for signing by adding singing_only in the SP

### DIFF
--- a/lib/Net/SAML2/SP.pm
+++ b/lib/Net/SAML2/SP.pm
@@ -175,6 +175,8 @@ has 'cert'   => (isa => 'Str', is => 'ro', required => 1, predicate => 'has_cert
 has 'key'    => (isa => 'Str', is => 'ro', required => 1);
 has 'cacert' => (isa => 'Str', is => 'rw', required => 0, predicate => 'has_cacert');
 
+has 'signing_only' => (isa => 'Bool', is => 'ro', required => 0);
+
 has 'encryption_key'   => (isa => 'Str', is => 'ro', required => 0, predicate => 'has_encryption_key');
 has 'error_url'        => (isa => Uri, is => 'ro', required => 1, coerce => 1);
 has 'org_name'         => (isa => 'Str', is => 'ro', required => 1);
@@ -653,6 +655,8 @@ sub _generate_key_descriptors {
         && !$self->sign_metadata;
 
     my $key = $use eq 'encryption' ? $self->_encryption_key_text : $self->_cert_text;
+
+    $use = 'signing' if $self->signing_only && $use eq 'both';
 
     return $x->KeyDescriptor(
         $md,

--- a/t/02-create-sp.t
+++ b/t/02-create-sp.t
@@ -219,6 +219,20 @@ use URN::OASIS::SAML2 qw(:bindings :urn);
     }
 
 }
+
+{
+    my $sp = net_saml2_sp(signing_only => 1);
+    my $xpath = get_xpath(
+        $sp->metadata,
+        md => URN_METADATA,
+        ds => URN_SIGNATURE,
+    );
+
+
+    my $kd = get_single_node_ok($xpath, "//md:KeyDescriptor");
+    is($kd->getAttribute('use'), 'signing', "Key descriptor says sign");
+}
+
 {
     my $sp = net_saml2_sp( ( encryption_key => 't/sign-nopw-cert.pem' ) );
 


### PR DESCRIPTION
In 3c87e51 we defined the signing key to be for signing and encryption. This new flag allows consumers to keep old behaviour where the key was/is only used for signing and not encrypting.