### PR TITLE
Set key to be only for signing by adding signing_only in the SP

### DIFF
--- a/lib/Net/SAML2/SP.pm
+++ b/lib/Net/SAML2/SP.pm
@@ -74,6 +74,11 @@ Path to the private key for the signing certificate
 Path to the public key that the IdP should use for encryption. This
 is used when generating the metadata.
 
+=item B<signing_only>
+
+Indicate that the key for signing is exclusively used for signing and not
+encryption and signing.
+
 =item B<cacert>
 
 Path to the CA certificate for verification
@@ -174,6 +179,8 @@ has 'issuer' => (isa => 'Str', is => 'ro', required => 1);
 has 'cert'   => (isa => 'Str', is => 'ro', required => 1, predicate => 'has_cert');
 has 'key'    => (isa => 'Str', is => 'ro', required => 1);
 has 'cacert' => (isa => 'Str', is => 'rw', required => 0, predicate => 'has_cacert');
+
+has 'signing_only' => (isa => 'Bool', is => 'ro', required => 0);
 
 has 'encryption_key'   => (isa => 'Str', is => 'ro', required => 0, predicate => 'has_encryption_key');
 has 'error_url'        => (isa => Uri, is => 'ro', required => 1, coerce => 1);
@@ -653,6 +660,8 @@ sub _generate_key_descriptors {
         && !$self->sign_metadata;
 
     my $key = $use eq 'encryption' ? $self->_encryption_key_text : $self->_cert_text;
+
+    $use = 'signing' if $self->signing_only && $use eq 'both';
 
     return $x->KeyDescriptor(
         $md,

--- a/t/02-create-sp.t
+++ b/t/02-create-sp.t
@@ -219,6 +219,46 @@ use URN::OASIS::SAML2 qw(:bindings :urn);
     }
 
 }
+
+{
+    my $sp = net_saml2_sp(signing_only => 1);
+    my $xpath = get_xpath(
+        $sp->metadata,
+        md => URN_METADATA,
+        ds => URN_SIGNATURE,
+    );
+
+
+    my $kd = get_single_node_ok($xpath, "//md:KeyDescriptor");
+    is($kd->getAttribute('use'), 'signing', "Key descriptor says sign");
+}
+
+{
+    my $sp = net_saml2_sp();
+    my $xpath = get_xpath(
+        $sp->metadata,
+        md => URN_METADATA,
+        ds => URN_SIGNATURE,
+    );
+
+
+    my $kd = get_single_node_ok($xpath, "//md:KeyDescriptor");
+    is($kd->getAttribute('use'), undef, "Key descriptor says nothing about use");
+}
+
+{
+    my $sp = net_saml2_sp(signing_only => 0);
+    my $xpath = get_xpath(
+        $sp->metadata,
+        md => URN_METADATA,
+        ds => URN_SIGNATURE,
+    );
+
+
+    my $kd = get_single_node_ok($xpath, "//md:KeyDescriptor");
+    is($kd->getAttribute('use'), undef, "Key descriptor says nothing about use");
+}
+
 {
     my $sp = net_saml2_sp( ( encryption_key => 't/sign-nopw-cert.pem' ) );
 


### PR DESCRIPTION
In 3c87e51 we defined the signing key to be for signing and encryption. This new flag allows consumers to keep old behaviour where the key was/is only used for signing and not encrypting.