### PR TITLE
Include `xml:lang` attribute in ServiceName and ServiceDescription

### DIFF
--- a/lib/Net/SAML2/AttributeConsumingService.pm
+++ b/lib/Net/SAML2/AttributeConsumingService.pm
@@ -66,8 +66,8 @@ sub to_xml {
             index     => $self->index,
             isDefault => $self->default,
         },
-        $xml->ServiceName($self->namespace, undef, $self->service_name),
-        $self->_has_service_description ? $xml->ServiceDescription($self->namespace, undef, $self->service_description) : (),
+        $xml->ServiceName($self->namespace, { 'xml:lang' => 'en' }, $self->service_name),
+        $self->_has_service_description ? $xml->ServiceDescription($self->namespace, { 'xml:lang' => 'en' }, $self->service_description) : (),
         map { $_->to_xml } @{ $self->attributes },
     );
 }

--- a/t/02-create-sp.t
+++ b/t/02-create-sp.t
@@ -480,6 +480,8 @@ use URN::OASIS::SAML2 qw(:bindings :urn);
         'Net::SAML2 testsuite',
         ".. with the correct value"
     );
+    is($child[0]->getAttribute("xml:lang"),
+        "en", ".. and xml:lang is set");
 
     is($child[1]->nodeName, "md:RequestedAttribute",
         "Requested attribute found");

--- a/t/28-attribute-consuming-service.t
+++ b/t/28-attribute-consuming-service.t
@@ -24,6 +24,11 @@ is(
     "Net::SAML2 testsuite",
     ".. and has the correct content"
 );
+is(
+    $node->getAttribute('xml:lang'),
+    "en",
+    ".. and has the correct xml:lang"
+);
 
 $node = get_single_node_ok($xpath,
     '/md:AttributeConsumingService/md:RequestedAttribute');


### PR DESCRIPTION
The SAML2 metadata documentation states that these fields are of the `localizedNameType` type. This means that an `xml:lang` attribute that indicates which language the text is written in, is required.

This change adds this attribute, with a value of `en` (just like for md:OrganizationName etc.)

Fixes #223 