### PR TITLE
Use "true" and "false" for more boolean values

### DIFF
--- a/lib/Net/SAML2/AttributeConsumingService.pm
+++ b/lib/Net/SAML2/AttributeConsumingService.pm
@@ -64,7 +64,7 @@ sub to_xml {
         $self->namespace,
         {
             index     => $self->index,
-            isDefault => $self->default,
+            isDefault => $self->default ? 'true' : 'false',
         },
         $xml->ServiceName($self->namespace, undef, $self->service_name),
         $self->_has_service_description ? $xml->ServiceDescription($self->namespace, undef, $self->service_description) : (),

--- a/lib/Net/SAML2/RequestedAttribute.pm
+++ b/lib/Net/SAML2/RequestedAttribute.pm
@@ -59,7 +59,7 @@ sub _build_attributes {
   my $self = shift;
 
   my %attrs = (
-    $self->required ? (isRequired => 1) : (),
+    $self->required ? (isRequired => 'true') : (),
     Name => $self->name,
     $self->_has_friendly ? (FriendlyName => $self->friendly_name) : (),
   );

--- a/t/02-create-sp.t
+++ b/t/02-create-sp.t
@@ -385,7 +385,7 @@ use URN::OASIS::SAML2 qw(:bindings :urn);
                 {
                     Binding  => BINDING_HTTP_ARTIFACT,
                     Location => 'https://foo.example.com/acs-http-artifact',
-                    isDefault => 0,
+                    isDefault => 'false',
                 }
             ],
             error_url => 'https://foo.example.com/error-url',
@@ -469,7 +469,7 @@ use URN::OASIS::SAML2 qw(:bindings :urn);
     my $acs  = get_single_node_ok($node,  '//md:AttributeConsumingService');
 
     is($acs->getAttribute('index'),     1, ".. index is 1");
-    is($acs->getAttribute('isDefault'), 0, "Not the default");
+    is($acs->getAttribute('isDefault'), 'false', "Not the default");
 
 
     my @child = $acs->childNodes();
@@ -486,7 +486,7 @@ use URN::OASIS::SAML2 qw(:bindings :urn);
     is($child[1]->getAttribute('FriendlyName'),
         'foo', ".. with the correct friendly name");
     is($child[1]->getAttribute('Name'),       'urn:foo:bar', ".. and name");
-    is($child[1]->getAttribute('isRequired'), '1', ".. and requiredness");
+    is($child[1]->getAttribute('isRequired'), 'true', ".. and requiredness");
 }
 
 {


### PR DESCRIPTION
Some IdPs (KPN) don't understand "1" and "0" as boolean values, but insist that the standard says only "true" or "false" are allowed.

A previous commit (bcfc4d249e332628ccab913e12c7b472201ee85f) already fixed several occurences, but it turned out there are more booleans hiding in the metadata XML.