### PR TITLE
Bump the requirement for XML::Sig to 0.66

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This software is copyright (c) 2024 by Venda Ltd, see the CONTRIBUTORS file for others.
+This software is copyright (c) 2025 by Venda Ltd, see the CONTRIBUTORS file for others.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
@@ -12,7 +12,7 @@ b) the "Artistic License"
 
 --- The GNU General Public License, Version 1, February 1989 ---
 
-This software is Copyright (c) 2024 by Venda Ltd, see the CONTRIBUTORS file for others.
+This software is Copyright (c) 2025 by Venda Ltd, see the CONTRIBUTORS file for others.
 
 This is free software, licensed under:
 
@@ -272,7 +272,7 @@ That's all there is to it!
 
 --- The Perl Artistic License 1.0 ---
 
-This software is Copyright (c) 2024 by Venda Ltd, see the CONTRIBUTORS file for others.
+This software is Copyright (c) 2025 by Venda Ltd, see the CONTRIBUTORS file for others.
 
 This is free software, licensed under:
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -53,7 +53,7 @@ my %WriteMakefileArgs = (
     "XML::Generator" => "1.13",
     "XML::LibXML" => 0,
     "XML::LibXML::XPathContext" => 0,
-    "XML::Sig" => "0.64",
+    "XML::Sig" => "0.66",
     "namespace::autoclean" => 0
   },
   "TEST_REQUIRES" => {
@@ -129,7 +129,7 @@ my %FallbackPrereqs = (
   "XML::Generator" => "1.13",
   "XML::LibXML" => 0,
   "XML::LibXML::XPathContext" => 0,
-  "XML::Sig" => "0.64",
+  "XML::Sig" => "0.66",
   "namespace::autoclean" => 0
 );
 

--- a/README
+++ b/README
@@ -105,7 +105,7 @@ AUTHORS
     *   Timothy Legge <timlegge@gmail.com>
 
 COPYRIGHT AND LICENSE
-    This software is copyright (c) 2024 by Venda Ltd, see the CONTRIBUTORS
+    This software is copyright (c) 2025 by Venda Ltd, see the CONTRIBUTORS
     file for others.
 
     This is free software; you can redistribute it and/or modify it under

--- a/cpanfile
+++ b/cpanfile
@@ -37,7 +37,7 @@ requires "XML::Enc" => "0.13";
 requires "XML::Generator" => "1.13";
 requires "XML::LibXML" => "0";
 requires "XML::LibXML::XPathContext" => "0";
-requires "XML::Sig" => "0.64";
+requires "XML::Sig" => "0.66";
 requires "namespace::autoclean" => "0";
 requires "perl" => "5.014";
 

--- a/dist.ini
+++ b/dist.ini
@@ -57,7 +57,7 @@ skip = feature
 [Prereqs / RuntimeRequires]
 perl = 5.014
 XML::Enc = 0.13
-XML::Sig = 0.64
+XML::Sig = 0.66
 ; Here because it isn't provided by Crypt::OpenSSL::RSA
 Crypt::OpenSSL::Bignum = 0
 URN::OASIS::SAML2 = 0.004


### PR DESCRIPTION
0.65 returns an error which does not exist in 0.66. Which seem to be related to Crypt::OpenSSL::RSA disabling use_pkcs1_padding.