### PR TITLE
fix: align Net::SAML2 runtime version with 0.84 release

### DIFF
--- a/lib/Net/SAML2.pm
+++ b/lib/Net/SAML2.pm
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 package Net::SAML2;
-our $VERSION = '0.82';
+our $VERSION = '0.84';
 
 require 5.012;
 


### PR DESCRIPTION
Hi there,

Net-SAML2-0.84 currently ships lib/Net/SAML2.pm with:

```pm
our $VERSION = '0.82';
```

This causes tooling such as `cpanm` to repeatedly treat the module as outdated and reinstall it ("upgraded from 0.82") on subsequent runs.

Update the module runtime version to 0.84 so it matches the released distribution metadata and restores idempotent installs.

---

_P.S. The same issue exists in tag 0.83 too (lib/Net/SAML2.pm still 0.82)._