### PR TITLE
Fixes #249 Make cert_text a first class anchor

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,7 @@ Revision history for Perl extension Net::SAML2.
     strongly recommended. Fixes:
     - CVE-2026-18089
     - CVE-2026-18092
+    - CVE-2026-18108
 
     [Significant Changes]
     BREAKING CHANGE: a trust anchor (cacert or cert_text) is now required to
@@ -101,6 +102,7 @@ Revision history for Perl extension Net::SAML2.
     strongly recommended. Fixes:
     - CVE-2026-18089
     - CVE-2026-18092
+    - CVE-2026-18108
 
     [Significant Changes]
     BREAKING CHANGE: a trust anchor (cacert or cert_text) is now required to

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -52,7 +52,7 @@ my %WriteMakefileArgs = (
     "XML::Generator" => "1.13",
     "XML::LibXML" => 0,
     "XML::LibXML::XPathContext" => 0,
-    "XML::Sig" => "0.67",
+    "XML::Sig" => "0.72",
     "namespace::autoclean" => 0
   },
   "TEST_REQUIRES" => {
@@ -131,7 +131,7 @@ my %FallbackPrereqs = (
   "XML::Generator" => "1.13",
   "XML::LibXML" => 0,
   "XML::LibXML::XPathContext" => 0,
-  "XML::Sig" => "0.67",
+  "XML::Sig" => "0.72",
   "namespace::autoclean" => 0
 );
 

--- a/cpanfile
+++ b/cpanfile
@@ -36,7 +36,7 @@ requires "XML::Enc" => "0.13";
 requires "XML::Generator" => "1.13";
 requires "XML::LibXML" => "0";
 requires "XML::LibXML::XPathContext" => "0";
-requires "XML::Sig" => "0.67";
+requires "XML::Sig" => "0.72";
 requires "namespace::autoclean" => "0";
 requires "perl" => "5.014";
 

--- a/dist.ini
+++ b/dist.ini
@@ -60,7 +60,7 @@ skip = feature
 [Prereqs / RuntimeRequires]
 perl = 5.014
 XML::Enc = 0.13
-XML::Sig = 0.67
+XML::Sig = 0.72
 URN::OASIS::SAML2 = 0.007
 XML::Generator = 1.13
 

--- a/lib/Net/SAML2/Object/Response.pm
+++ b/lib/Net/SAML2/Object/Response.pm
@@ -68,11 +68,18 @@ Returns the nodes of the assertion
 
 =head2 cacert
 
-path to the CA certificate for verification.  This is required for
-validating the certificate provided for a Response.
+path to the CA certificate for verification.  Trusts the certificate
+embedded in the document once it chains to this CA.
 
-It is required for ensuring that the Response is properly
-validated.
+One of C<cacert> or C<cert_text> is required for ensuring that the
+Response is properly validated.
+
+=head2 cert_text
+
+text form of the IdP signing certificate (FORMAT_PEM).  Pins that exact
+certificate instead of accepting anything that chains to a CA, and is
+propagated to the Assertion by C<to_assertion> exactly as C<cacert> is.
+See L<Net::SAML2::Protocol::Assertion/new_from_xml>.
 
 =head2 insecure_trust_embedded_cert
 
@@ -80,7 +87,7 @@ Boolean, default false. When true, C<to_assertion> proceeds with
 no pre-configured trust anchor (every embedded signing certificate
 is accepted). B<This disables effective signature verification and
 is intended only for local testing.> Production deployments must
-leave this false and supply C<cacert>.
+leave this false and supply C<cacert> or C<cert_text>.
 
 =cut
 
@@ -116,6 +123,11 @@ has 'cacert'     => (
     is => 'ro',
     required => 0);
 
+has 'cert_text'  => (
+    isa => 'Str',
+    is => 'ro',
+    required => 0);
+
 has 'insecure_trust_embedded_cert' => (
     isa       => 'Bool',
     is        => 'ro',
@@ -136,10 +148,11 @@ around BUILDARGS => sub {
 
     my %params = @_;
     unless ($params{cacert}
+         || $params{cert_text}
          || $params{insecure_trust_embedded_cert}) {
         croak(
-            "Net::SAML2::Object::Response->new() requires 'cacert' "
-          . "on the object to verify SAML response signatures. "
+            "Net::SAML2::Object::Response->new() requires 'cacert' or "
+          . "'cert_text' on the object to verify SAML response signatures. "
           . "To explicitly disable signature verification (test/dev only) "
           . ", pass insecure_trust_embedded_cert => 1 to new()."
         );
@@ -163,6 +176,7 @@ sub new_from_xml {
     my $xml            = no_comments($args{xml});
     my $destination    = delete $args{destination};
     my $cacert         = delete $args{cacert};
+    my $cert_text      = delete $args{cert_text};
     my $insecure_trust_embedded_cert    = delete $args{insecure_trust_embedded_cert};
 
     # The default may change in the future
@@ -231,6 +245,7 @@ sub new_from_xml {
         in_response_to => $response->getAttribute('InResponseTo'),
         $nodes->size ? (assertions => $nodes) : (),
         $cacert ? (cacert => $cacert) : (),
+        $cert_text ? (cert_text => $cert_text) : (),
         $insecure_trust_embedded_cert ? (insecure_trust_embedded_cert => $insecure_trust_embedded_cert) : (),
         require_signed_response => $require_signed_response,
     );
@@ -269,6 +284,7 @@ sub to_assertion {
     # built with none.  Caller-supplied %args still override these defaults.
     return Net::SAML2::Protocol::Assertion->new_from_xml(
         $self->cacert ? (cacert => $self->cacert) : (),
+        $self->cert_text ? (cert_text => $self->cert_text) : (),
         $self->insecure_trust_embedded_cert
             ? (insecure_trust_embedded_cert => $self->insecure_trust_embedded_cert)
             : (),

--- a/lib/Net/SAML2/Protocol/Assertion.pm
+++ b/lib/Net/SAML2/Protocol/Assertion.pm
@@ -95,24 +95,39 @@ used by the IdP to Encrypt the response (or parts of the response)
 
 =item B<cacert>
 
-path to the CA certificate for verification.  Optional: This is only used for
-validating the certificate provided for a signed Assertion that was found
-when the EncryptedAssertion is decrypted.
+path to the CA certificate for verification.
 
-While optional it is recommended for ensuring that the Assertion in an
-EncryptedAssertion is properly validated.
-
-C<cacert> verifies the signature against the certificate embedded in the
-document's C<KeyInfo>.  When the IdP references its signing key by
-C<KeyName> or C<RetrievalMethod> (no embedded C<X509Certificate>), use
-C<cert_text> instead.
+C<cacert> trusts the certificate embedded in the document's own C<KeyInfo>,
+but only once that certificate chains to the CA.  A trust anchor is only as
+narrow as the CA behind it: any certificate issued under that CA is accepted,
+so point C<cacert> at the IdP's own certificate (or a dedicated
+single-purpose CA) rather than a public/corporate root.  When the IdP
+references its signing key by C<KeyName> or C<RetrievalMethod> (no embedded
+C<X509Certificate>), use C<cert_text> instead.
 
 =item B<cert_text>
 
 text form of the IdP signing certificate (FORMAT_PEM) used to verify the
-assertion signature.  Unlike C<cacert>, this B<pins> a specific
-certificate: the signature is verified directly against it. One of
-C<cacert>, C<cert_text> or C<insecure_trust_embedded_cert> is required.
+assertion signature.  Unlike C<cacert>, this B<pins> a specific certificate:
+signatures are verified directly against it and the document's own C<KeyInfo>
+is never consulted.  That makes C<cert_text> the stronger of the two anchors
+on the key-trust axis - a certificate issued by the same CA as the IdP's
+does not satisfy it.
+
+One of C<cacert>, C<cert_text> or C<insecure_trust_embedded_cert> is required.
+
+Pinning is exact.  Every signature the assertion is extracted from must be
+made by the pinned certificate, so an IdP that rotates signing certificates
+needs C<cert_text> updated in step with the rotation (or C<cacert> pointed
+at a CA narrow enough to cover only that IdP).
+
+=item B<insecure_trust_embedded_cert>
+
+Boolean, default false.  When true, no trust anchor is required and the
+certificate embedded in the document is trusted as-is.  B<This disables
+effective signature verification, and with it the signature-wrapping
+defences that anchor assertion extraction.>  Intended only for local
+testing.
 
 =item B<require_signed_assertion>
 
@@ -340,25 +355,29 @@ sub _get_trusted_assertion {
 }
 
 sub _trusted_signature_refs {
-    my ($class, $xpath, $cacert) = @_;
+    my ($class, $xpath, $cacert, $cert_text) = @_;
 
-    return unless $cacert;
+    return unless $cacert || $cert_text;
 
-    my $ca = Crypt::OpenSSL::Verify->new($cacert, { strict_certs => 0 });
+    my $ca = $cacert
+        ? Crypt::OpenSSL::Verify->new($cacert, { strict_certs => 0 })
+        : undef;
 
-    # We are looking for references for trusted Signature nodes here
-    # the X509Certificate of each signature is verified against the
-    # cacert and a list of trusted references is created
     my @trusted_refs;
     for my $sig ($xpath->findnodes('//dsig:Signature')) {
-        my $pem = $class->get_pem_from_keynode($sig);
-        my $cert_obj = try { Crypt::OpenSSL::X509->new_from_string($pem) };
-        next unless $cert_obj;
+        my @verify_with;
 
-        # Crypt::OpenSSL::Verify->verify can both return a bool AND die on
-        # parse / chain failure; treat both as untrusted.
-        my $ok = try { $ca->verify($cert_obj) };
-        next unless $ok;
+        if ($cert_text) {
+            push @verify_with, $cert_text;      # pinned: KeyInfo is never consulted
+        }
+        elsif ($ca) {
+            my $pem = $class->get_pem_from_keynode($sig);
+            my $cert_obj = try { Crypt::OpenSSL::X509->new_from_string($pem) };
+            push @verify_with, $pem
+                if $cert_obj && try { $ca->verify($cert_obj) };
+        }
+
+        next unless @verify_with;
 
         my $ref = $xpath->findvalue(
             './dsig:SignedInfo/dsig:Reference/@URI', $sig);
@@ -369,7 +388,7 @@ sub _trusted_signature_refs {
 
         my $resolved = $xpath->findnodes("//*[\@ID='$ref']");
 
-        # A CA-trusted signature whose Reference URI resolves to more than
+        # A trusted signature whose Reference URI resolves to more than
         # one element is an active XSW1 (duplicate-ID) attack - fail closed.
         die("XSW guard: trusted signature Reference URI '$ref' is "
             . "ambiguous (matched " . $resolved->size . " elements)")
@@ -378,12 +397,16 @@ sub _trusted_signature_refs {
         next unless $resolved->size == 1;
         my $node = $resolved->get_node(1);
 
-        my $genuine = try {
-            Net::SAML2::XML::Sig->new({
-                cert_text          => $pem,
-                no_xml_declaration => 1,
-            })->verify($node->toString);
-        };
+        my $genuine;
+        for my $pem (@verify_with) {
+            $genuine = try {
+                Net::SAML2::XML::Sig->new({
+                    cert_text          => $pem,
+                    no_xml_declaration => 1,
+                })->verify($node->toString);
+            };
+            last if $genuine;
+        }
         next unless $genuine;
 
         push @trusted_refs, $ref;
@@ -471,26 +494,24 @@ sub new_from_xml {
     my $xml = no_comments($args{xml});
     $xpath->setContextNode($xml);
 
+    my $trust_anchor = $cacert || $cert_text;
+
     my $actual_destination = $class->_get_actual_destination($destination, $xpath);
-    if ($cacert && $xpath->findnodes('//dsig:Signature')->size > 0) {
+    if ($trust_anchor && $xpath->findnodes('//dsig:Signature')->size > 0) {
         my $verifier = Net::SAML2::XML::Sig->new({
             x509               => 1,
+            $cert_text ? (cert_text => $cert_text) : (),
             no_xml_declaration => 1,
         });
 
         my $ok = try {
             $verifier->verify($xml->toString)
         } catch {
-            croak(sprintf(
-                "XML signature verification failed in new_from_xml%s",
-                $_ ? " ($_)" : '',
-            ));
+            croak("XML signature verification failed in new_from_xml ($_)");
         };
         # XML::Sig can croak or return 0 in event that the signature fails
-        croak(sprintf(
-            "XML signature verification failed in new_from_xml%s",
-            $_ ? " ($_)" : '',
-        )) unless $ok;
+        croak("XML signature verification failed in new_from_xml")
+            unless $ok;
     }
 
     $xml = $class->_verify_encrypted_assertion(
@@ -510,12 +531,14 @@ sub new_from_xml {
     );
     $xpath->setContextNode($dec);
 
-    my @trusted_refs = $class->_trusted_signature_refs($xpath, $cacert);
+    my @trusted_refs
+        = $class->_trusted_signature_refs($xpath, $cacert, $cert_text);
     my $sig_count = $xpath->findnodes('//dsig:Signature')->size;
-    if ($cacert && $sig_count > 0 && !@trusted_refs) {
+    if ($trust_anchor && $sig_count > 0 && !@trusted_refs) {
         croak(
-            "No <dsig:Signature> in the document chains to the configured "
-          . "cacert. Refusing to extract assertion content."
+            "No <dsig:Signature> in the document validates against the "
+          . "configured " . ($cacert ? 'cacert' : 'cert_text')
+          . ". Refusing to extract assertion content."
         );
     }
 
@@ -538,9 +561,9 @@ sub new_from_xml {
 
     my $assertion_node = $class->_get_trusted_assertion($xpath, \@candidate_refs);
 
-    if ($cacert && $sig_count > 0 && !$assertion_node) {
+    if ($trust_anchor && $sig_count > 0 && !$assertion_node) {
         croak(
-            "XSW guard: no CA-trusted signature anchors a <saml:Assertion>. "
+            "XSW guard: no trusted signature anchors a <saml:Assertion>. "
           . "Refusing to extract assertion content via document order."
         );
     }

--- a/lib/Net/SAML2/SP.pm
+++ b/lib/Net/SAML2/SP.pm
@@ -582,17 +582,27 @@ sub soap_binding {
     );
 }
 
-=head2 post_binding( )
+=head2 post_binding( %args )
 
 Returns a POST binding object for this SP.
+
+Any arguments are passed through to L<Net::SAML2::Binding::POST/new> and
+override the SP's own defaults.  In particular C<cert_text> pins the IdP's
+signing certificate for response verification:
+
+    my $post = $sp->post_binding(cert_text => $idp->cert('signing')->[0]);
 
 =cut
 
 sub post_binding {
-    my ($self) = @_;
+    my ($self, %args) = @_;
 
     return Net::SAML2::Binding::POST->new(
-        $self->has_cacert ? (cacert => $self->cacert) : ()
+        $self->has_cacert ? (cacert => $self->cacert) : (),
+        $self->insecure_trust_embedded_cert ? (
+            insecure_trust_embedded_cert => $self->insecure_trust_embedded_cert
+        ) : (),
+        %args,
     );
 }
 

--- a/t/03-assertions.t
+++ b/t/03-assertions.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::Lib;
 use Test::Net::SAML2;
+use File::Slurper qw/read_text/;
 use MIME::Base64 qw/decode_base64/;
 
 use Net::SAML2::Protocol::Assertion;
@@ -313,5 +314,90 @@ is($assertion->subjectlocality_dnsname,
 is($assertion->contextclass_authncontextclassref,
     'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
     "AuthnContext AuthnContextClassRef is ok");
+
+my $unsigned_xml = <<UNSIGNED_XML;
+<?xml version="1.0"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="s29e656961dc650775c103fddadba836256cc3eb7d" InResponseTo="N3k95Hg41WCHdwc9mqXynLPhB" Version="2.0" IssueInstant="2010-10-12T14:49:27Z" Destination="http://ct.local/saml/consumer-post">
+  <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">http://sso.dev.venda.com/opensso</saml:Issuer>
+  <samlp:Status xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+    <samlp:StatusCode xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="s241001b6007d1700109a3e3bc4350ae5528ba9824" IssueInstant="2010-10-12T14:49:27Z" Version="2.0">
+    <saml:Issuer>http://sso.dev.venda.com/opensso</saml:Issuer>
+    <saml:Subject>
+      <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" NameQualifier="http://sso.dev.venda.com/opensso">nKdwzcgBYGt42xovLuctZ60tyafv</saml:NameID>
+      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData InResponseTo="N3k95Hg41WCHdwc9mqXynLPhB" NotOnOrAfter="2010-10-12T14:59:27Z" Recipient="http://ct.local/saml/consumer-post"/>
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotBefore="2010-10-12T14:39:27Z" NotOnOrAfter="2010-10-12T14:59:27Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>http://ct.local</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement AuthnInstant="2010-10-12T12:58:34Z" SessionIndex="s2b087bdce06dbbf9cd4662af82b8b853d4d285c01">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="Phone2">
+        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">123456</saml:AttributeValue>
+        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">234567</saml:AttributeValue>
+        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">345678</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="EmailAddress">
+        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">demo&#64;sso.venda.com</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>
+UNSIGNED_XML
+
+use Net::SAML2::XML::Sig;
+my $signer = Net::SAML2::XML::Sig->new({
+        key => 't/net-saml2-key.pem',
+        cert => 't/net-saml2-cert.pem',
+        x509 => 1,
+    });
+
+# create a signature
+my $signed = $signer->sign($unsigned_xml);
+
+my $ca_cert_text = read_text('t/net-saml2-cacert.pem');
+
+my $cert_text = read_text('t/net-saml2-cert.pem');
+
+throws_ok(sub { Net::SAML2::Protocol::Assertion->new_from_xml(
+                    xml => $signed,
+                );},
+                qr/'cacert' or 'cert_text' is required to verify assertion signatures/,
+                'No trust anchor fails'
+        );
+
+my $cert_text_assertion;
+lives_ok(sub { $cert_text_assertion = Net::SAML2::Protocol::Assertion->new_from_xml(
+                    xml         => $signed,
+                    cert_text   => $cert_text,
+                );},
+                'cert_text only trust anchor succeeds'
+        );
+
+is($cert_text_assertion->nameid, 'nKdwzcgBYGt42xovLuctZ60tyafv', "Finds the name_id");
+
+throws_ok(sub { Net::SAML2::Protocol::Assertion->new_from_xml(
+                    xml         => $signed,
+                    cert_text   => $ca_cert_text,
+                );},
+                qr/XML signature verification failed in new_from_xml/,
+                'CA based cert_text fails to verify'
+        );
+
+lives_ok(sub { Net::SAML2::Protocol::Assertion->new_from_xml(
+                    xml     => $signed,
+                    cacert  => 't/net-saml2-cacert.pem',
+                );},
+                'CA based cacert anchor succeeds verification'
+        );
 
 done_testing;

--- a/t/33-cert-text-anchor.t
+++ b/t/33-cert-text-anchor.t
@@ -1,0 +1,430 @@
+use strict;
+use warnings;
+use Test::Lib;
+use Test::Net::SAML2;
+use File::Temp qw(tempdir);
+use POSIX qw(strftime);
+
+use Net::SAML2::Protocol::Assertion;
+use Net::SAML2::Object::Response;
+use XML::Sig;
+
+# cert_text (certificate pinning) must be a first-class trust anchor:
+# every defence a cacert deployment gets, a cert_text deployment gets
+# too. This file mirrors t/32-xsw-defenses.t with cert_text in place of
+# cacert, and adds the case cacert cannot defend - an attacker holding a
+# certificate issued by the same CA as the IdP.
+
+my $dir = tempdir(CLEANUP => 1);
+my $idp_key = "$dir/idp.key";
+my $idp_crt = "$dir/idp.crt";
+system("openssl genrsa -out $idp_key 2048 2>/dev/null") == 0 or die "idp keygen";
+system("openssl req -new -x509 -key $idp_key -out $idp_crt -days 1 "
+     . "-subj '/CN=Test IdP' 2>/dev/null") == 0 or die "idp certgen";
+
+sub slurp {
+    my $file = shift;
+    open my $fh, '<', $file or die "open $file: $!";
+    local $/;
+    return <$fh>;
+}
+
+my $idp_pem = slurp($idp_crt);
+
+sub make_assertion {
+    my %p = @_;
+    my $id     = $p{id}     // "_legit_" . int(rand(1e9));
+    my $nameid = $p{nameid} // 'lowuser@victim.com';
+    my $now    = strftime("%Y-%m-%dT%H:%M:%SZ", gmtime(time - 60));
+    my $exp    = strftime("%Y-%m-%dT%H:%M:%SZ", gmtime(time + 3600));
+
+    return <<"XML";
+<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="$id" Version="2.0" IssueInstant="$now">
+  <saml:Issuer>http://idp.test/idp</saml:Issuer>
+  <saml:Subject>
+    <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">$nameid</saml:NameID>
+    <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+      <saml:SubjectConfirmationData InResponseTo="_req_$$" NotOnOrAfter="$exp" Recipient="http://sp.test/saml/post"/>
+    </saml:SubjectConfirmation>
+  </saml:Subject>
+  <saml:Conditions NotBefore="$now" NotOnOrAfter="$exp">
+    <saml:AudienceRestriction>
+      <saml:Audience>http://sp.test</saml:Audience>
+    </saml:AudienceRestriction>
+  </saml:Conditions>
+  <saml:AuthnStatement AuthnInstant="$now" SessionIndex="_sess_$$">
+    <saml:AuthnContext>
+      <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
+    </saml:AuthnContext>
+  </saml:AuthnStatement>
+  <saml:AttributeStatement>
+    <saml:Attribute Name="role">
+      <saml:AttributeValue>user</saml:AttributeValue>
+    </saml:Attribute>
+  </saml:AttributeStatement>
+</saml:Assertion>
+XML
+}
+
+sub wrap_in_response {
+    my %p = @_;
+    my $inner = $p{inner};
+    my $resp_id = "_resp_$$" . "_" . int(rand(1e9));
+    my $now = strftime("%Y-%m-%dT%H:%M:%SZ", gmtime());
+    return <<"XML";
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="$resp_id" Version="2.0" IssueInstant="$now"
+                InResponseTo="_req_$$"
+                Destination="http://sp.test/saml/post">
+  <saml:Issuer>http://idp.test/idp</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+$inner
+</samlp:Response>
+XML
+}
+
+my $signer = XML::Sig->new({
+    x509               => 1,
+    key                => $idp_key,
+    cert               => $idp_crt,
+    no_xml_declaration => 1,
+});
+
+# See t/32-xsw-defenses.t - moves the Signature to the schema-required
+# position without disturbing the canonical form that was digested.
+sub sign_schema_compliant {
+    my ($s, $xml) = @_;
+    my $signed = $s->sign($xml);
+    my ($sig) = $signed =~ m{(<(?:ds|dsig):Signature\b.*?</(?:ds|dsig):Signature>)}s;
+    return $signed unless $sig;
+    $signed =~ s{\Q$sig\E}{}s;
+    $signed =~ s{(</saml:Issuer>)}{$1$sig}s;
+    return $signed;
+}
+
+# ============================================================
+# Sanity: cert_text ALONE is a working trust anchor
+#
+# Previously _trusted_signature_refs consulted cacert only, so a
+# cert_text-only caller satisfied the constructor guard and then always
+# croaked "No trusted signature found" - pinning was accepted at the
+# door and unusable in practice.
+# ============================================================
+{
+    my $response = wrap_in_response(
+        inner => sign_schema_compliant($signer, make_assertion()));
+
+    my $a = eval {
+        Net::SAML2::Protocol::Assertion->new_from_xml(
+            xml       => $response,
+            cert_text => $idp_pem,
+        );
+    };
+    ok($a, 'cert_text alone: legit signed assertion parses') or diag $@;
+    is($a && $a->nameid, 'lowuser@victim.com',
+        'cert_text alone: nameid extracted');
+}
+
+# ============================================================
+# cert_text and cacert together
+# ============================================================
+{
+    my $response = wrap_in_response(
+        inner => sign_schema_compliant($signer, make_assertion()));
+
+    my $a = eval {
+        Net::SAML2::Protocol::Assertion->new_from_xml(
+            xml       => $response,
+            cert_text => $idp_pem,
+            cacert    => $idp_crt,
+        );
+    };
+    ok($a, 'cert_text + cacert: legit signed assertion parses') or diag $@;
+}
+
+# ============================================================
+# A signature by any other key is rejected under pinning
+# ============================================================
+{
+    my $atk_key = "$dir/atk.key";
+    my $atk_crt = "$dir/atk.crt";
+    system("openssl genrsa -out $atk_key 2048 2>/dev/null") == 0 or die "atk keygen";
+    system("openssl req -new -x509 -key $atk_key -out $atk_crt -days 1 "
+         . "-subj '/CN=Evil Attacker' 2>/dev/null") == 0 or die "atk certgen";
+
+    my $atk_signer = XML::Sig->new({
+        x509               => 1,
+        key                => $atk_key,
+        cert               => $atk_crt,
+        no_xml_declaration => 1,
+    });
+
+    my $response = wrap_in_response(inner => sign_schema_compliant(
+        $atk_signer, make_assertion(nameid => 'admin@victim.com')));
+
+    throws_ok(
+        sub {
+            Net::SAML2::Protocol::Assertion->new_from_xml(
+                xml       => $response,
+                cert_text => $idp_pem,
+            );
+        },
+        qr/signature verification failed|does not validate against|No trusted signature/,
+        'cert_text: assertion signed by an unpinned key is rejected'
+    );
+}
+
+# ============================================================
+# The case cacert cannot defend: attacker holds a certificate
+# issued by the SAME CA as the IdP.
+#
+# cacert accepts it - it chains. cert_text does not - it is not the
+# pinned certificate. This is why cert_text is not merely equal to
+# cacert on the key-trust axis but strictly stronger.
+# ============================================================
+{
+    my $ca_key = "$dir/ca.key";
+    my $ca_crt = "$dir/ca.crt";
+    system("openssl genrsa -out $ca_key 2048 2>/dev/null") == 0 or die "ca keygen";
+    system("openssl req -new -x509 -key $ca_key -out $ca_crt -days 1 "
+         . "-subj '/CN=Shared CA' 2>/dev/null") == 0 or die "ca certgen";
+
+    my %leaf;
+    for my $who (qw(idp atk)) {
+        my $k = "$dir/$who-ca.key";
+        my $r = "$dir/$who-ca.csr";
+        my $c = "$dir/$who-ca.crt";
+        system("openssl genrsa -out $k 2048 2>/dev/null") == 0 or die "$who keygen";
+        system("openssl req -new -key $k -out $r -subj '/CN=$who under CA' 2>/dev/null") == 0
+            or die "$who csr";
+        system("openssl x509 -req -in $r -CA $ca_crt -CAkey $ca_key "
+             . "-CAcreateserial -out $c -days 1 2>/dev/null") == 0 or die "$who sign";
+        $leaf{$who} = { key => $k, crt => $c };
+    }
+
+    # Attacker signs an escalated assertion with their CA-issued cert.
+    my $atk_signer = XML::Sig->new({
+        x509               => 1,
+        key                => $leaf{atk}{key},
+        cert               => $leaf{atk}{crt},
+        no_xml_declaration => 1,
+    });
+    my $response = wrap_in_response(inner => sign_schema_compliant(
+        $atk_signer, make_assertion(nameid => 'admin@victim.com')));
+
+    # cacert pointed at the shared CA accepts it.
+    my $via_cacert = eval {
+        Net::SAML2::Protocol::Assertion->new_from_xml(
+            xml    => $response,
+            cacert => $ca_crt,
+        );
+    };
+    is($via_cacert && $via_cacert->nameid, 'admin@victim.com',
+        'broad cacert accepts an attacker certificate issued by the same CA');
+
+    # cert_text pinned to the IdP's leaf refuses it.
+    throws_ok(
+        sub {
+            Net::SAML2::Protocol::Assertion->new_from_xml(
+                xml       => $response,
+                cert_text => slurp($leaf{idp}{crt}),
+            );
+        },
+        qr/signature verification failed|does not validate against|No trusted signature/,
+        'cert_text refuses an attacker certificate issued by the same CA'
+    );
+}
+
+# ============================================================
+# XSW different-ID wrapping is defended under cert_text
+# (mirrors t/32 Test 3)
+# ============================================================
+{
+    my $signed_legit = sign_schema_compliant($signer,
+        make_assertion(id => "_legit_" . int(rand(1e9)),
+                       nameid => 'lowuser@victim.com'));
+
+    my $atk_xml = make_assertion(id => "_attacker_" . int(rand(1e9)),
+                                 nameid => 'admin@victim.com');
+
+    my $response = wrap_in_response(
+        inner => "$atk_xml\n<wrapper xmlns=\"urn:wrapper\">$signed_legit</wrapper>");
+
+    my $a = eval {
+        Net::SAML2::Protocol::Assertion->new_from_xml(
+            xml       => $response,
+            cert_text => $idp_pem,
+        );
+    };
+    my $err = $@;
+    ok($a, 'XSW different-ID under cert_text: returned an Assertion') or diag $err;
+    is($a && $a->nameid, 'lowuser@victim.com',
+        'XSW different-ID under cert_text: extracted NameID is the LEGIT one');
+}
+
+# ============================================================
+# XSW1 duplicate-ID fails closed under cert_text
+# (mirrors t/32 Test 2)
+# ============================================================
+{
+    my $legit_id = "_dup_" . int(rand(1e9));
+    my $signed_legit = sign_schema_compliant($signer,
+        make_assertion(id => $legit_id, nameid => 'lowuser@victim.com'));
+
+    # Same ID, no signature, escalated NameID.
+    my $atk_xml = make_assertion(id => $legit_id, nameid => 'admin@victim.com');
+
+    my $response = wrap_in_response(
+        inner => "$atk_xml\n<wrapper xmlns=\"urn:wrapper\">$signed_legit</wrapper>");
+
+    throws_ok(
+        sub {
+            Net::SAML2::Protocol::Assertion->new_from_xml(
+                xml       => $response,
+                cert_text => $idp_pem,
+            );
+        },
+        qr/ambiguous|signature verification failed/,
+        'XSW1 duplicate-ID under cert_text: fails closed'
+    );
+}
+
+# ============================================================
+# Multi-signature attack is defended under cert_text
+# (mirrors t/32 Test 4)
+# ============================================================
+{
+    my $atk_key = "$dir/atk2.key";
+    my $atk_crt = "$dir/atk2.crt";
+    system("openssl genrsa -out $atk_key 2048 2>/dev/null") == 0 or die "atk2 keygen";
+    system("openssl req -new -x509 -key $atk_key -out $atk_crt -days 1 "
+         . "-subj '/CN=Evil Attacker 2' 2>/dev/null") == 0 or die "atk2 certgen";
+
+    my $atk_signer = XML::Sig->new({
+        x509               => 1,
+        key                => $atk_key,
+        cert               => $atk_crt,
+        no_xml_declaration => 1,
+    });
+
+    # Attacker's own validly-signed (by their own cert) escalated assertion
+    # first in document order, the IdP-signed one second.
+    my $signed_atk = sign_schema_compliant($atk_signer,
+        make_assertion(id => "_atk_" . int(rand(1e9)), nameid => 'admin@victim.com'));
+    my $signed_legit = sign_schema_compliant($signer,
+        make_assertion(id => "_legit_" . int(rand(1e9)), nameid => 'lowuser@victim.com'));
+
+    my $response = wrap_in_response(inner => "$signed_atk\n$signed_legit");
+
+    my $a = eval {
+        Net::SAML2::Protocol::Assertion->new_from_xml(
+            xml       => $response,
+            cert_text => $idp_pem,
+        );
+    };
+    my $err = $@;
+
+    # Under pinning the attacker's signature does not validate against the
+    # pinned certificate at all, so either outcome is safe: the document is
+    # rejected outright, or extraction anchors at the IdP-signed subtree.
+    if ($a) {
+        is($a->nameid, 'lowuser@victim.com',
+            'multi-sig under cert_text: extracted NameID is the pinned-signer one');
+    }
+    else {
+        like($err, qr/signature verification failed|No trusted signature|does not validate against/,
+            'multi-sig under cert_text: rejected outright');
+    }
+}
+
+# ============================================================
+# Multiple <samlp:Response> in one document (mirrors t/32 Test 5)
+# ============================================================
+{
+    my $now = strftime("%Y-%m-%dT%H:%M:%SZ", gmtime(time - 60));
+    my $legit_resp_id = "_legit_resp_" . int(rand(1e9));
+
+    my $legit_resp_unsigned = <<"XML";
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="$legit_resp_id" Version="2.0" IssueInstant="$now"
+                InResponseTo="_req_$$"
+                Destination="http://sp.test/saml/post">
+  <saml:Issuer>http://idp.test/idp</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+@{[ make_assertion(id => "_legit_asn_" . int(rand(1e9)),
+                  nameid => 'lowuser@victim.com') ]}
+</samlp:Response>
+XML
+
+    my $legit_signed_response = sign_schema_compliant($signer, $legit_resp_unsigned);
+
+    my $atk_asn_xml = make_assertion(
+        id     => "_atk_asn_" . int(rand(1e9)),
+        nameid => 'admin@victim.com',
+    );
+
+    my $multi_response = wrap_in_response(
+        inner => "$atk_asn_xml\n<wrapper xmlns=\"urn:wrapper\">$legit_signed_response</wrapper>");
+
+    my $a = eval {
+        Net::SAML2::Protocol::Assertion->new_from_xml(
+            xml       => $multi_response,
+            cert_text => $idp_pem,
+        );
+    };
+    my $err = $@;
+    ok($a, 'multi-response under cert_text: returned an Assertion') or diag $err;
+    is($a && $a->nameid, 'lowuser@victim.com',
+        'multi-response under cert_text: NameID is from the signed Response');
+}
+
+# ============================================================
+# Object::Response accepts cert_text and propagates it to the
+# Assertion, so pinning callers are never pushed onto
+# insecure_trust_embedded_cert (which would disable the XSW anchor).
+# ============================================================
+{
+    my $signed_legit = sign_schema_compliant($signer,
+        make_assertion(id => "_legit_" . int(rand(1e9)),
+                       nameid => 'lowuser@victim.com'));
+    my $atk_xml = make_assertion(id => "_attacker_" . int(rand(1e9)),
+                                 nameid => 'admin@victim.com');
+    my $xsw = wrap_in_response(
+        inner => "$atk_xml\n<wrapper xmlns=\"urn:wrapper\">$signed_legit</wrapper>");
+
+    my $response = eval {
+        Net::SAML2::Object::Response->new_from_xml(
+            xml       => $xsw,
+            cert_text => $idp_pem,
+        );
+    };
+    ok($response, 'Object::Response accepts cert_text as a trust anchor') or diag $@;
+
+    my $a = $response && eval { $response->to_assertion() };
+    ok($a, 'Object::Response->to_assertion works under cert_text') or diag $@;
+    is($a && $a->nameid, 'lowuser@victim.com',
+        'Object::Response propagates cert_text: XSW anchor still applies');
+}
+
+# ============================================================
+# No anchor at all is still refused by Object::Response
+# ============================================================
+{
+    my $response = wrap_in_response(
+        inner => sign_schema_compliant($signer, make_assertion()));
+
+    throws_ok(
+        sub { Net::SAML2::Object::Response->new_from_xml(xml => $response) },
+        qr/requires 'cacert' or 'cert_text'/,
+        'Object::Response still refuses to build with no trust anchor'
+    );
+}
+
+done_testing;


### PR DESCRIPTION
cert_text with XML::Sig (which needs a documentation update) ignores any X509 data in the XML and "pins" the verification certificate to the certificate passed in cert_text.

both cacert and cert_text can be used but cert_text is more secure since it does not trust a signature signed a different certificate issued by the same CA as the trusted certificate.