### PR TITLE
Add support for `cert_text` in Net::SAML2::Object::Response

### DIFF
--- a/lib/Net/SAML2/Object/Response.pm
+++ b/lib/Net/SAML2/Object/Response.pm
@@ -74,6 +74,14 @@ validating the certificate provided for a Response.
 It is required for ensuring that the Response is properly
 validated.
 
+=head2 cert_text
+
+text form (FORMAT_PEM) of the IdP signing certificate. Unlike C<cacert>,
+this B<pins> a specific certificate rather than verifying a CA chain: an
+embedded signature is trusted only when its certificate is byte-for-byte
+this one. Propagated to C<to_assertion> the same way C<cacert> is -- see
+L<Net::SAML2::Protocol::Assertion/new_from_xml> for how it's used there.
+
 =head2 insecure_trust_embedded_cert
 
 Boolean, default false. When true, C<to_assertion> proceeds with
@@ -116,6 +124,11 @@ has 'cacert'     => (
     is => 'ro',
     required => 0);
 
+has 'cert_text'  => (
+    isa => 'Str',
+    is => 'ro',
+    required => 0);
+
 has 'insecure_trust_embedded_cert' => (
     isa       => 'Bool',
     is        => 'ro',
@@ -136,10 +149,11 @@ around BUILDARGS => sub {
 
     my %params = @_;
     unless ($params{cacert}
+         || $params{cert_text}
          || $params{insecure_trust_embedded_cert}) {
         croak(
-            "Net::SAML2::Object::Response->new() requires 'cacert' "
-          . "on the object to verify SAML response signatures. "
+            "Net::SAML2::Object::Response->new() requires 'cacert' or "
+          . "'cert_text' on the object to verify SAML response signatures. "
           . "To explicitly disable signature verification (test/dev only) "
           . ", pass insecure_trust_embedded_cert => 1 to new()."
         );
@@ -163,6 +177,7 @@ sub new_from_xml {
     my $xml            = no_comments($args{xml});
     my $destination    = delete $args{destination};
     my $cacert         = delete $args{cacert};
+    my $cert_text      = delete $args{cert_text};
     my $insecure_trust_embedded_cert    = delete $args{insecure_trust_embedded_cert};
 
     # The default may change in the future
@@ -231,6 +246,7 @@ sub new_from_xml {
         in_response_to => $response->getAttribute('InResponseTo'),
         $nodes->size ? (assertions => $nodes) : (),
         $cacert ? (cacert => $cacert) : (),
+        $cert_text ? (cert_text => $cert_text) : (),
         $insecure_trust_embedded_cert ? (insecure_trust_embedded_cert => $insecure_trust_embedded_cert) : (),
         require_signed_response => $require_signed_response,
     );
@@ -264,11 +280,13 @@ sub to_assertion {
 
     # Propagate the trust configuration from the Response so the Assertion
     # inherits the same trust anchor.  Without this the caller would have to
-    # supply cacert (or insecure_trust_embedded_cert) a second time, and a
-    # Response built with a trust anchor could silently produce an Assertion
-    # built with none.  Caller-supplied %args still override these defaults.
+    # supply cacert/cert_text (or insecure_trust_embedded_cert) a second
+    # time, and a Response built with a trust anchor could silently produce
+    # an Assertion built with none.  Caller-supplied %args still override
+    # these defaults.
     return Net::SAML2::Protocol::Assertion->new_from_xml(
         $self->cacert ? (cacert => $self->cacert) : (),
+        $self->cert_text ? (cert_text => $self->cert_text) : (),
         $self->insecure_trust_embedded_cert
             ? (insecure_trust_embedded_cert => $self->insecure_trust_embedded_cert)
             : (),

--- a/lib/Net/SAML2/Protocol/Assertion.pm
+++ b/lib/Net/SAML2/Protocol/Assertion.pm
@@ -95,24 +95,33 @@ used by the IdP to Encrypt the response (or parts of the response)
 
 =item B<cacert>
 
-path to the CA certificate for verification.  Optional: This is only used for
-validating the certificate provided for a signed Assertion that was found
-when the EncryptedAssertion is decrypted.
+path to the CA certificate for verification.  Used both for validating the
+certificate embedded in a signed (plain or decrypted-from-Encrypted)
+C<saml:Assertion>, and the certificate provided for a signed Assertion found
+when an C<EncryptedAssertion> is decrypted.
 
-While optional it is recommended for ensuring that the Assertion in an
-EncryptedAssertion is properly validated.
+While optional it is recommended for ensuring that the Assertion is
+properly validated.
 
-C<cacert> verifies the signature against the certificate embedded in the
-document's C<KeyInfo>.  When the IdP references its signing key by
-C<KeyName> or C<RetrievalMethod> (no embedded C<X509Certificate>), use
+C<cacert> verifies that the certificate embedded in the document's
+C<KeyInfo> chains, via a real X.509 CA-verification, to the given CA
+certificate. This requires the IdP's signing certificate to actually be
+issued by (or be) that CA. It will not succeed merely because you trust
+the IdP's signing certificate directly, unless that certificate happens to
+be self-signed. For an IdP that references its signing key by C<KeyName> or
+C<RetrievalMethod> (no embedded C<X509Certificate>), or for pinning a
+CA-issued certificate directly rather than verifying a chain, use
 C<cert_text> instead.
 
 =item B<cert_text>
 
 text form of the IdP signing certificate (FORMAT_PEM) used to verify the
-assertion signature.  Unlike C<cacert>, this B<pins> a specific
-certificate: the signature is verified directly against it. One of
-C<cacert>, C<cert_text> or C<insecure_trust_embedded_cert> is required.
+assertion signature, both for a plain (or decrypted) C<saml:Assertion> and
+for a signed Assertion found when an C<EncryptedAssertion> is decrypted.
+Unlike C<cacert>, this B<pins> a specific certificate: the signature is
+trusted only when the certificate embedded in the document is byte-for-byte
+this certificate, regardless of what issued it. One of C<cacert>,
+C<cert_text> or C<insecure_trust_embedded_cert> is required.
 
 =item B<require_signed_assertion>
 
@@ -340,25 +349,47 @@ sub _get_trusted_assertion {
 }
 
 sub _trusted_signature_refs {
-    my ($class, $xpath, $cacert) = @_;
+    my ($class, $xpath, $cacert, $cert_text) = @_;
 
-    return unless $cacert;
+    return unless $cacert || $cert_text;
 
-    my $ca = Crypt::OpenSSL::Verify->new($cacert, { strict_certs => 0 });
+    my $ca = $cacert
+        ? Crypt::OpenSSL::Verify->new($cacert, { strict_certs => 0 })
+        : undef;
 
-    # We are looking for references for trusted Signature nodes here
-    # the X509Certificate of each signature is verified against the
-    # cacert and a list of trusted references is created
+    # cert_text pins one specific certificate: rather than asking whether
+    # the embedded cert chains to a CA, we ask whether it *is* (byte for
+    # byte) the certificate the caller told us to trust. Comparing DER
+    # bytes sidesteps any PEM formatting/whitespace differences between
+    # what's embedded in the document and what the caller supplied.
+    my $pinned_cert_obj = $cert_text
+        ? try { Crypt::OpenSSL::X509->new_from_string($cert_text) }
+        : undef;
+
+    # We are looking for references for trusted Signature nodes here.
+    # The X509Certificate of each signature is checked against the cacert
+    # (CA-chain trust) and/or cert_text (exact pin), and a list of trusted
+    # references is created from whichever ones pass.
     my @trusted_refs;
     for my $sig ($xpath->findnodes('//dsig:Signature')) {
         my $pem = $class->get_pem_from_keynode($sig);
         my $cert_obj = try { Crypt::OpenSSL::X509->new_from_string($pem) };
         next unless $cert_obj;
 
-        # Crypt::OpenSSL::Verify->verify can both return a bool AND die on
-        # parse / chain failure; treat both as untrusted.
-        my $ok = try { $ca->verify($cert_obj) };
-        next unless $ok;
+        my $trusted = 0;
+
+        if ($ca) {
+            # Crypt::OpenSSL::Verify->verify can both return a bool AND die
+            # on parse / chain failure; treat both as untrusted.
+            $trusted ||= !!(try { $ca->verify($cert_obj) });
+        }
+
+        if (!$trusted && $pinned_cert_obj) {
+            $trusted ||= ($cert_obj->fingerprint_sha256
+                eq $pinned_cert_obj->fingerprint_sha256);
+        }
+
+        next unless $trusted;
 
         my $ref = $xpath->findvalue(
             './dsig:SignedInfo/dsig:Reference/@URI', $sig);
@@ -369,7 +400,7 @@ sub _trusted_signature_refs {
 
         my $resolved = $xpath->findnodes("//*[\@ID='$ref']");
 
-        # A CA-trusted signature whose Reference URI resolves to more than
+        # A trusted signature whose Reference URI resolves to more than
         # one element is an active XSW1 (duplicate-ID) attack - fail closed.
         die("XSW guard: trusted signature Reference URI '$ref' is "
             . "ambiguous (matched " . $resolved->size . " elements)")
@@ -472,7 +503,7 @@ sub new_from_xml {
     $xpath->setContextNode($xml);
 
     my $actual_destination = $class->_get_actual_destination($destination, $xpath);
-    if ($cacert && $xpath->findnodes('//dsig:Signature')->size > 0) {
+    if (($cacert || $cert_text) && $xpath->findnodes('//dsig:Signature')->size > 0) {
         my $verifier = Net::SAML2::XML::Sig->new({
             x509               => 1,
             no_xml_declaration => 1,
@@ -510,12 +541,13 @@ sub new_from_xml {
     );
     $xpath->setContextNode($dec);
 
-    my @trusted_refs = $class->_trusted_signature_refs($xpath, $cacert);
+    my @trusted_refs = $class->_trusted_signature_refs($xpath, $cacert, $cert_text);
     my $sig_count = $xpath->findnodes('//dsig:Signature')->size;
-    if ($cacert && $sig_count > 0 && !@trusted_refs) {
+    if (($cacert || $cert_text) && $sig_count > 0 && !@trusted_refs) {
         croak(
             "No <dsig:Signature> in the document chains to the configured "
-          . "cacert. Refusing to extract assertion content."
+          . "cacert, or matches the configured cert_text. Refusing to "
+          . "extract assertion content."
         );
     }
 
@@ -538,9 +570,9 @@ sub new_from_xml {
 
     my $assertion_node = $class->_get_trusted_assertion($xpath, \@candidate_refs);
 
-    if ($cacert && $sig_count > 0 && !$assertion_node) {
+    if (($cacert || $cert_text) && $sig_count > 0 && !$assertion_node) {
         croak(
-            "XSW guard: no CA-trusted signature anchors a <saml:Assertion>. "
+            "XSW guard: no trusted signature anchors a <saml:Assertion>. "
           . "Refusing to extract assertion content via document order."
         );
     }

--- a/t/33-cert-text-pinning.t
+++ b/t/33-cert-text-pinning.t
@@ -1,0 +1,256 @@
+use strict;
+use warnings;
+use Test::Lib;
+use Test::Net::SAML2;
+use File::Temp qw(tempdir);
+use POSIX qw(strftime);
+
+use Net::SAML2::Protocol::Assertion;
+use Net::SAML2::Object::Response;
+use XML::Sig;
+
+# cert_text pins one exact certificate; cacert verifies a CA chain instead.
+# Real IdPs often publish a CA-issued (not self-signed) signing cert, which
+# cacert-chain verification can't trust unless the caller also trusts that
+# CA -- not how SAML metadata trust works. Per OASIS "SAML V2.0 Metadata
+# Interoperability Profile Version 1.0" (24 Oct 2019), section 2.6.1 "Key
+# Processing", a consumer "MUST NOT apply additional criteria of any kind
+# on the acceptance, or validity, of the keys found within" metadata: trust
+# is keyed on the published certificate itself, no CA chain involved.
+#
+# This file builds that shape (a small CA + a leaf cert it issues) and
+# verifies cert_text as the trust anchor instead, in both
+# Protocol::Assertion and Object::Response -- the latter previously
+# accepted cert_text but silently dropped it without ever using it
+my $dir = tempdir(CLEANUP => 1);
+
+my $ca_key = "$dir/ca.key";
+my $ca_crt = "$dir/ca.crt";
+system("openssl genrsa -out $ca_key 2048 2>/dev/null") == 0 or die "ca keygen";
+system("openssl req -new -x509 -key $ca_key -out $ca_crt -days 1 "
+     . "-subj '/CN=Test Intermediate CA' 2>/dev/null") == 0 or die "ca certgen";
+
+my $idp_key = "$dir/idp.key";
+my $idp_csr = "$dir/idp.csr";
+my $idp_crt = "$dir/idp.crt";
+system("openssl genrsa -out $idp_key 2048 2>/dev/null") == 0 or die "idp keygen";
+system("openssl req -new -key $idp_key -out $idp_csr "
+     . "-subj '/CN=Test IdP (CA-issued)' 2>/dev/null") == 0 or die "idp csr";
+system("openssl x509 -req -in $idp_csr -CA $ca_crt -CAkey $ca_key -CAcreateserial "
+     . "-out $idp_crt -days 1 2>/dev/null") == 0 or die "idp certgen (CA-issued)";
+
+sub make_assertion {
+    my %p = @_;
+    my $id     = $p{id}     // "_legit_" . int(rand(1e9));
+    my $nameid = $p{nameid} // 'lowuser@victim.com';
+    my $issuer = $p{issuer} // 'http://idp.test/idp';
+    my $now    = strftime("%Y-%m-%dT%H:%M:%SZ", gmtime(time - 60));
+    my $exp    = strftime("%Y-%m-%dT%H:%M:%SZ", gmtime(time + 3600));
+    my $aud    = $p{audience} // 'http://sp.test';
+    my $recip  = $p{recipient} // 'http://sp.test/saml/post';
+
+    return <<"XML";
+<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="$id" Version="2.0" IssueInstant="$now">
+  <saml:Issuer>$issuer</saml:Issuer>
+  <saml:Subject>
+    <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">$nameid</saml:NameID>
+    <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+      <saml:SubjectConfirmationData InResponseTo="_req_$$" NotOnOrAfter="$exp" Recipient="$recip"/>
+    </saml:SubjectConfirmation>
+  </saml:Subject>
+  <saml:Conditions NotBefore="$now" NotOnOrAfter="$exp">
+    <saml:AudienceRestriction>
+      <saml:Audience>$aud</saml:Audience>
+    </saml:AudienceRestriction>
+  </saml:Conditions>
+  <saml:AuthnStatement AuthnInstant="$now" SessionIndex="_sess_$$">
+    <saml:AuthnContext>
+      <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
+    </saml:AuthnContext>
+  </saml:AuthnStatement>
+</saml:Assertion>
+XML
+}
+
+sub wrap_in_response {
+    my %p = @_;
+    my $inner = $p{inner};
+    my $resp_id = "_resp_$$" . "_" . int(rand(1e9));
+    my $now = strftime("%Y-%m-%dT%H:%M:%SZ", gmtime());
+    my $dest = $p{destination} // 'http://sp.test/saml/post';
+    # Net::SAML2::Role::ProtocolMessage's in_response_to is `isa => XsdID`
+    # (not Maybe[XsdID]), and Object::Response::new_from_xml unconditionally
+    # passes it through from the Response's InResponseTo attribute -- so it
+    # must always be present and a valid xsd:ID, even though these fixtures
+    # don't model a real preceding AuthnRequest.
+    my $in_response_to = "_authnreq_" . int(rand(1e9));
+    return <<"XML";
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="$resp_id" Version="2.0" IssueInstant="$now"
+                InResponseTo="$in_response_to"
+                Destination="$dest">
+  <saml:Issuer>http://idp.test/idp</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+$inner
+</samlp:Response>
+XML
+}
+
+my $signer = XML::Sig->new({
+    x509               => 1,
+    key                => $idp_key,
+    cert               => $idp_crt,
+    no_xml_declaration => 1,
+});
+
+# See t/32-xsw-defenses.t for why the Signature needs repositioning.
+sub sign_schema_compliant {
+    my ($s, $xml) = @_;
+    my $signed = $s->sign($xml);
+    my ($sig) = $signed =~ m{(<(?:ds|dsig):Signature\b.*?</(?:ds|dsig):Signature>)}s;
+    return $signed unless $sig;
+    $signed =~ s{\Q$sig\E}{}s;
+    $signed =~ s{(</saml:Issuer>)}{$1$sig}s;
+    return $signed;
+}
+
+my $idp_crt_pem = do {
+    open my $fh, '<', $idp_crt or die $!;
+    local $/;
+    <$fh>;
+};
+
+# ============================================================
+# Sanity:
+# cacert-chain verification should fail for a CA-issued (not self-signed) cert
+# used as its own "CA file".
+# This is the exact production setup for DigiD/Logius: the metadata only
+# contains a "leaf" certificate signed by QuoVadis that is used for signing,
+# not any of the intermediates or root CA certificate.
+# ============================================================
+{
+    my $assertion_xml = make_assertion(nameid => 'lowuser@victim.com');
+    my $signed = sign_schema_compliant($signer, $assertion_xml);
+    my $response = wrap_in_response(inner => $signed);
+
+    throws_ok(
+        sub {
+            Net::SAML2::Protocol::Assertion->new_from_xml(
+                xml    => $response,
+                cacert => $idp_crt,
+            );
+        },
+        qr/chains to the configured cacert/,
+        'sanity: cacert-chain verification fails for a CA-issued (non-self-signed) cert'
+    );
+}
+
+# ============================================================
+# Test 1: cert_text pins the same CA-issued cert directly and succeeds
+# ============================================================
+{
+    my $assertion_xml = make_assertion(nameid => 'lowuser@victim.com');
+    my $signed = sign_schema_compliant($signer, $assertion_xml);
+    my $response = wrap_in_response(inner => $signed);
+
+    my $a = eval {
+        Net::SAML2::Protocol::Assertion->new_from_xml(
+            xml       => $response,
+            cert_text => $idp_crt_pem,
+        );
+    };
+    ok($a, 'cert_text pins a CA-issued cert successfully') or diag $@;
+    is($a && $a->nameid, 'lowuser@victim.com', 'correct nameid extracted via cert_text pinning');
+}
+
+# ============================================================
+# Test 2: a non-matching cert_text is rejected, not silently trusted
+# ============================================================
+{
+    my ($wrong_key, $wrong_csr, $wrong_crt) = ("$dir/wrong.key", "$dir/wrong.csr", "$dir/wrong.crt");
+    system("openssl genrsa -out $wrong_key 2048 2>/dev/null") == 0 or die "wrong keygen";
+    system("openssl req -new -key $wrong_key -out $wrong_csr "
+         . "-subj '/CN=Wrong CA-issued IdP' 2>/dev/null") == 0 or die "wrong csr";
+    system("openssl x509 -req -in $wrong_csr -CA $ca_crt -CAkey $ca_key -CAcreateserial "
+         . "-out $wrong_crt -days 1 2>/dev/null") == 0 or die "wrong certgen";
+    my $wrong_crt_pem = do {
+        open my $fh, '<', $wrong_crt or die $!;
+        local $/;
+        <$fh>;
+    };
+
+    my $assertion_xml = make_assertion(nameid => 'lowuser@victim.com');
+    my $signed = sign_schema_compliant($signer, $assertion_xml);
+    my $response = wrap_in_response(inner => $signed);
+
+    throws_ok(
+        sub {
+            Net::SAML2::Protocol::Assertion->new_from_xml(
+                xml       => $response,
+                cert_text => $wrong_crt_pem,
+            );
+        },
+        qr/chains to the configured cacert|No trusted signature found/,
+        'a cert_text that does not match the embedded cert is rejected'
+    );
+}
+
+# ============================================================
+# Test 3: XSW different-ID wrapping is still defended under cert_text
+# pinning (mirrors t/32-xsw-defenses.t's Test 3, but with cert_text
+# instead of cacert as the trust anchor)
+# ============================================================
+{
+    my $legit_id = "_legit_" . int(rand(1e9));
+    my $legit_xml = make_assertion(id => $legit_id, nameid => 'lowuser@victim.com');
+    my $signed_legit = sign_schema_compliant($signer, $legit_xml);
+
+    my $atk_id = "_attacker_" . int(rand(1e9));
+    my $atk_xml = make_assertion(id => $atk_id, nameid => 'admin@victim.com');
+
+    my $payload = "$atk_xml\n<wrapper xmlns=\"urn:wrapper\">$signed_legit</wrapper>";
+    my $response = wrap_in_response(inner => $payload);
+
+    my $a = eval {
+        Net::SAML2::Protocol::Assertion->new_from_xml(
+            xml       => $response,
+            cert_text => $idp_crt_pem,
+        );
+    };
+    my $err = $@;
+    ok($a, 'XSW different-ID under cert_text pinning: new_from_xml returned an Assertion')
+        or diag $err;
+    is($a && $a->nameid, 'lowuser@victim.com',
+        'XSW different-ID under cert_text pinning: extracted NameID is the LEGIT one');
+}
+
+# ============================================================
+# Test 4: Object::Response actually reads and propagates cert_text
+# ============================================================
+{
+    my $assertion_xml = make_assertion(nameid => 'lowuser@victim.com');
+    my $signed = sign_schema_compliant($signer, $assertion_xml);
+    my $response_xml = wrap_in_response(inner => $signed);
+
+    my $response = eval {
+        Net::SAML2::Object::Response->new_from_xml(
+            xml       => $response_xml,
+            cert_text => $idp_crt_pem,
+        );
+    };
+    ok($response, 'Object::Response accepts cert_text without requiring cacert')
+        or diag $@;
+    ok($response && $response->success, 'response status is success');
+
+    my $a = eval { $response->to_assertion };
+    ok($a, 'to_assertion() succeeds using the cert_text propagated from Response')
+        or diag $@;
+    is($a && $a->nameid, 'lowuser@victim.com',
+        'correct nameid extracted via Object::Response cert_text propagation');
+}
+
+done_testing;


### PR DESCRIPTION
Certificates passed as `cert_text` will be used as "pinned" certificates: signatures will be trusted _only_ when that exact certificate is used for signing the assertions.

Fixes: #249